### PR TITLE
Add download timeout, bag size estimation, and cache management tools

### DIFF
--- a/plugin/skills/create-dataset/SKILL.md
+++ b/plugin/skills/create-dataset/SKILL.md
@@ -33,7 +33,7 @@ All splits create nested child datasets automatically. Use `dry_run=true` to pre
 
 1. **Always create datasets within an execution** — Use `create_execution_dataset`, not bare `create_dataset`, to maintain provenance.
 2. **Register element types before adding members** — `add_dataset_element_type` must be called for each source table before `add_dataset_members`.
-3. **FK traversal in bag exports** — Downloaded bags include all FK-reachable records from registered element types. The export walks all foreign key paths (both directions) from member records, with vocabulary tables as natural terminators. Deep join chains (Image -> Sample -> Subject -> Study) can cause timeouts. Two fixes: (a) use `exclude_tables` to prune specific tables from the FK graph, or (b) add intermediate table records as direct members to flatten the traversal.
+3. **FK traversal in bag exports** — Downloaded bags include all FK-reachable records from registered element types. The export walks all foreign key paths (both directions) from member records, with vocabulary tables as natural terminators. Deep join chains (Image -> Sample -> Subject -> Study) can cause timeouts. Three fixes in order of preference: (a) increase `timeout` (default read timeout is 610s, e.g. `timeout=[10, 1800]` for 30 min), (b) use `exclude_tables` to prune specific tables from the FK graph, or (c) add intermediate table records as direct members to flatten the traversal.
 4. **Version after every modification** — Call `increment_dataset_version` after adding/removing members or changing element types.
 5. **Validate RIDs first** — Use `validate_rids` before `add_dataset_members` to catch invalid RIDs early.
 6. **Set seeds on splits** — Always pass `seed` to `split_dataset` for reproducibility.

--- a/plugin/skills/create-dataset/references/workflow.md
+++ b/plugin/skills/create-dataset/references/workflow.md
@@ -48,18 +48,25 @@ When a dataset is downloaded as a BDBag, the export follows foreign key relation
 
 #### When downloads are slow or timing out
 
-Deep FK chains (e.g., Image → Sample → Subject → Study → Institution) can produce expensive server-side joins that timeout. Two solutions:
+Deep FK chains (e.g., Image → Sample → Subject → Study → Institution) can produce expensive server-side joins that timeout. Three solutions, in order of preference:
 
-1. **Exclude tables from the FK graph** — Use the `exclude_tables` parameter on `download_dataset` to prune branches:
+1. **Increase the download timeout** — The default read timeout is 610 seconds (~10 min). For large datasets, increase it:
+   ```
+   download_dataset(dataset_rid="2-XXXX", version="1.0.0", timeout=[10, 1800])
+   ```
+   This gives the server 30 minutes per query. The first value (connect timeout) rarely needs changing.
+
+2. **Exclude tables from the FK graph** — If you don't need data from certain tables, prune them:
    ```
    download_dataset(dataset_rid="2-XXXX", version="1.0.0", exclude_tables=["Study", "Institution"])
    ```
-   This prevents traversal into those tables entirely. Use when the excluded tables' data is not needed.
+   This prevents traversal into those tables entirely.
 
-2. **Add intermediate records as direct members** — Register intermediate tables as element types and add their records as members. This replaces deep FK joins with simpler association lookups.
+3. **Add intermediate records as direct members** — Register intermediate tables as element types and add their records as members. This replaces deep FK joins with simpler association lookups.
 
-For Hydra-Zen configs, `exclude_tables` is available on both `DatasetSpecConfig` and `DatasetSpec`:
+For Hydra-Zen configs, both `timeout` and `exclude_tables` are available on `DatasetSpecConfig`:
 ```python
+DatasetSpecConfig(rid="28EA", version="0.4.0", timeout=[10, 1800])
 DatasetSpecConfig(rid="28EA", version="0.4.0", exclude_tables=["Study", "Institution"])
 ```
 

--- a/plugin/skills/create-dataset/references/workflow.md
+++ b/plugin/skills/create-dataset/references/workflow.md
@@ -329,6 +329,12 @@ When using `split_dataset`, child datasets are automatically nested under the pa
 
 ## Downloading and Using Datasets
 
+Before downloading, use `estimate_bag_size` to preview what the bag will contain:
+```
+estimate_bag_size(dataset_rid="2-DS01", version="1.0.0")
+```
+Returns row counts and asset sizes per table, so you can decide whether to use `exclude_tables` or adjust `timeout` before committing to the full download.
+
 For extracting, downloading, and preparing dataset data for ML training, see the `prepare-training-data` skill. For diagnosing missing data in bag exports, see the `debug-bag-contents` skill.
 
 ## Complete Example: End-to-End Dataset Workflow

--- a/plugin/skills/debug-bag-contents/SKILL.md
+++ b/plugin/skills/debug-bag-contents/SKILL.md
@@ -132,21 +132,35 @@ For each registered element type, examine the FK paths that the export will foll
 ### Deep join timeouts
 **Problem**: FK traversal through many intermediate tables causes slow exports or timeouts.
 
-**Fix — Option A (preferred): Exclude unnecessary tables from the FK graph.**
-Use the `exclude_tables` parameter on `download_dataset` or `download_execution_dataset` to prune branches of the FK graph that are causing the expensive joins:
+**Fix — Option A (preferred): Increase the download timeout.**
+The default network timeout is (10, 610) seconds — 10s to connect, 610s (~10 min) to read each query response. For large datasets with deep FK joins, increase the read timeout:
+
+```
+download_dataset(dataset_rid="2-XXXX", version="1.0.0", timeout=[10, 1800])
+```
+
+This gives the server 30 minutes per query instead of 10. The connect timeout (first value) rarely needs changing.
+
+For Hydra-Zen configs, add `timeout` to `DatasetSpecConfig`:
+```python
+DatasetSpecConfig(rid="28EA", version="0.4.0", timeout=[10, 1800])
+```
+
+**Fix — Option B: Exclude unnecessary tables from the FK graph.**
+If you don't need data from certain tables, prune them from the FK traversal:
 
 ```
 download_dataset(dataset_rid="2-XXXX", version="1.0.0", exclude_tables=["Study", "Protocol"])
 ```
 
-This prevents the export from traversing into those tables, avoiding the deep join entirely. Use this when the excluded tables' data is not needed in the bag.
+This prevents the export from traversing into those tables entirely. Use this when the excluded tables' data is not needed in the bag.
 
-For Hydra-Zen configs, add `exclude_tables` to `DatasetSpecConfig`:
+For Hydra-Zen configs:
 ```python
 DatasetSpecConfig(rid="28EA", version="0.4.0", exclude_tables=["Study", "Protocol"])
 ```
 
-**Fix — Option B: Flatten the traversal by adding direct members.**
+**Fix — Option C: Flatten the traversal by adding direct members.**
 Add records from intermediate tables as direct dataset members rather than relying on deep FK traversal. This replaces the deep join with simpler association-based lookups.
 
 ### Missing element type registration
@@ -195,7 +209,8 @@ Use this checklist when data is missing from a bag:
    - `increment_dataset_version` if members were recently changed.
 
 6. **Is the download timing out?**
-   - Use `exclude_tables` to prune expensive FK branches.
+   - First try increasing the timeout: `timeout=[10, 1800]` (30 min read timeout).
+   - If that's not enough, use `exclude_tables` to prune expensive FK branches.
    - Or add intermediate records as direct members to flatten the joins.
 
 7. **Preview before full download.**

--- a/plugin/skills/debug-bag-contents/SKILL.md
+++ b/plugin/skills/debug-bag-contents/SKILL.md
@@ -214,7 +214,7 @@ Use this checklist when data is missing from a bag:
    - Or add intermediate records as direct members to flatten the joins.
 
 7. **Preview before full download.**
-   - Check the bag preview resource to confirm expected counts before downloading.
+   - `estimate_bag_size` -- shows row counts and asset sizes per table before downloading.
 
 ## Related Tools
 
@@ -227,7 +227,8 @@ Use this checklist when data is missing from a bag:
 | `validate_dataset_bag` | Validate bag contents against expectations |
 | `increment_dataset_version` | Bump dataset version after changes |
 | `get_dataset_spec` | View dataset specification |
-| `download_dataset` | Download the dataset bag (supports `exclude_tables` for timeout recovery) |
+| `estimate_bag_size` | Preview row counts and asset sizes before downloading |
+| `download_dataset` | Download the dataset bag (supports `exclude_tables` and `timeout`) |
 | `denormalize_dataset` | Flatten dataset for analysis |
 | `query_table` | Inspect FK column values |
 | `get_table` | Check table schema and FK relationships |

--- a/plugin/skills/prepare-training-data/SKILL.md
+++ b/plugin/skills/prepare-training-data/SKILL.md
@@ -113,7 +113,11 @@ download_dataset(dataset_rid="2-XXXX", version="1.0.0")
 
 **When downloads are slow or timing out:**
 - Deep FK chains (e.g., Image → Sample → Subject → Study) can cause expensive joins
-- Use `exclude_tables` to prune specific tables from the FK graph:
+- **First**, increase the read timeout (default is 610s / ~10 min):
+  ```
+  download_dataset(dataset_rid="2-XXXX", version="1.0.0", timeout=[10, 1800])
+  ```
+- If the query is still too expensive, use `exclude_tables` to prune tables from the FK graph:
   ```
   download_dataset(dataset_rid="2-XXXX", version="1.0.0", exclude_tables=["Study", "Protocol"])
   ```

--- a/plugin/skills/prepare-training-data/SKILL.md
+++ b/plugin/skills/prepare-training-data/SKILL.md
@@ -94,6 +94,13 @@ query_table(
 
 Downloads the full dataset as a BDBag archive with all assets (files, images).
 
+**Preview size before downloading:**
+```
+estimate_bag_size(dataset_rid="2-XXXX", version="1.0.0")
+```
+Returns row counts and asset file sizes per table so you know what to expect.
+
+**Download:**
 ```
 download_dataset(dataset_rid="2-XXXX", version="1.0.0")
 ```

--- a/src/deriva_mcp/tools/dataset.py
+++ b/src/deriva_mcp/tools/dataset.py
@@ -795,6 +795,47 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             return json.dumps({"status": "error", "message": str(e)})
 
     @mcp.tool()
+    async def estimate_bag_size(
+        dataset_rid: str,
+        version: str,
+        exclude_tables: list[str] | None = None,
+    ) -> str:
+        """Estimate the size of a dataset bag before downloading.
+
+        Runs the same FK path traversal as download_dataset, then queries the
+        snapshot catalog for row counts and asset file sizes. Use this to
+        preview what a download will contain and how large it will be before
+        committing to the full download.
+
+        Args:
+            dataset_rid: RID of the dataset to estimate.
+            version: Semantic version to estimate (e.g., "1.0.0").
+            exclude_tables: Optional list of table names to exclude from FK
+                path traversal, same as in download_dataset.
+
+        Returns:
+            JSON with:
+                - tables: dict of table name -> {row_count, is_asset, asset_bytes}
+                - total_rows: total row count across all tables
+                - total_asset_bytes: total asset size in bytes
+                - total_asset_size: human-readable size (e.g., "1.2 GB")
+        """
+        try:
+            from deriva_ml.dataset.aux_classes import DatasetSpec
+
+            ml = conn_manager.get_active_or_raise()
+            spec = DatasetSpec(
+                rid=dataset_rid,
+                version=version,
+                exclude_tables=set(exclude_tables) if exclude_tables else None,
+            )
+            estimate = ml.estimate_bag_size(spec)
+            return json.dumps({"status": "success"} | estimate)
+        except Exception as e:
+            logger.error(f"Failed to estimate bag size: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    @mcp.tool()
     async def validate_dataset_bag(
         dataset_rid: str,
         version: str | None = None,

--- a/src/deriva_mcp/tools/dataset.py
+++ b/src/deriva_mcp/tools/dataset.py
@@ -709,6 +709,7 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
         version: str,
         materialize: bool = True,
         exclude_tables: list[str] | None = None,
+        timeout: list[int] | None = None,
     ) -> str:
         """Download a dataset version as a BDBag for local processing.
 
@@ -745,6 +746,9 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
                 visited, pruning branches of the FK graph. Use this when bag
                 downloads are slow or timing out due to expensive joins through
                 large intermediate tables.
+            timeout: Optional [connect_timeout, read_timeout] in seconds for
+                network requests. Default is [10, 610]. Increase read_timeout
+                for large datasets with deep FK joins that need more time.
 
         Returns:
             JSON with bag attributes: dataset_rid, version, description,
@@ -761,6 +765,7 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
                 version=version,
                 materialize=materialize,
                 exclude_tables=set(exclude_tables) if exclude_tables else None,
+                timeout=tuple(timeout) if timeout else None,
             )
             bag = ml.download_dataset_bag(spec)
 

--- a/src/deriva_mcp/tools/execution.py
+++ b/src/deriva_mcp/tools/execution.py
@@ -69,6 +69,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -815,71 +816,486 @@ def register_execution_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> N
 # =============================================================================
 
 
+def _human_readable_size(size_bytes: int) -> str:
+    """Convert bytes to human-readable string."""
+    if size_bytes == 0:
+        return "0 B"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    i = 0
+    size = float(size_bytes)
+    while size >= 1024 and i < len(units) - 1:
+        size /= 1024
+        i += 1
+    return f"{size:.1f} {units[i]}"
+
+
+def _discover_cache_dirs(connected_cache_dir: str | None = None, extra_dirs: list[str] | None = None) -> list[Path]:
+    """Discover all potential DerivaML cache directories.
+
+    Scans the default ~/.deriva-ml tree for any cache/ directories,
+    adds the connected catalog's cache_dir, and any explicitly provided paths.
+
+    Returns:
+        Deduplicated list of existing cache directory Paths.
+    """
+    from pathlib import Path
+
+    candidates: set[Path] = set()
+
+    # Scan default location: ~/.deriva-ml/*/*/cache/
+    default_root = Path.home() / ".deriva-ml"
+    if default_root.exists():
+        for cache_dir in default_root.rglob("cache"):
+            if cache_dir.is_dir():
+                candidates.add(cache_dir.resolve())
+
+    # Add connected catalog's cache dir
+    if connected_cache_dir:
+        p = Path(connected_cache_dir)
+        if p.exists():
+            candidates.add(p.resolve())
+
+    # Add any explicitly provided directories
+    for d in (extra_dirs or []):
+        p = Path(d)
+        if p.exists():
+            candidates.add(p.resolve())
+
+    return sorted(candidates)
+
+
+def _parse_cache_entry(entry_path: Path) -> dict[str, Any] | None:
+    """Parse a single cache directory entry into structured info.
+
+    Cache entries have the naming convention: {dataset_rid}_{checksum}
+    Inside is Dataset_{dataset_rid}/ containing the extracted bag.
+
+    Returns:
+        Dict with entry metadata, or None if not a valid cache entry.
+    """
+    import csv
+    from datetime import datetime
+
+    name = entry_path.name
+    # Parse {rid}_{checksum} format — RID is everything before the last underscore+hex
+    parts = name.rsplit("_", 1)
+    if len(parts) != 2:
+        return None
+
+    dataset_rid = parts[0]
+    checksum = parts[1]
+
+    # Calculate size
+    try:
+        size_bytes = sum(f.stat().st_size for f in entry_path.rglob("*") if f.is_file())
+        mtime = datetime.fromtimestamp(entry_path.stat().st_mtime)
+    except OSError:
+        return None
+
+    # Check materialization status
+    materialized = (entry_path / "validated_check.txt").exists()
+
+    # Try to extract description and version from Dataset.csv inside the bag
+    description = ""
+    bag_dir = entry_path / f"Dataset_{dataset_rid}"
+    dataset_csv = bag_dir / "data" / "Dataset.csv"
+    if dataset_csv.exists():
+        try:
+            with dataset_csv.open(newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    if row.get("RID") == dataset_rid:
+                        description = row.get("Description", "")
+                        break
+        except Exception:
+            pass
+
+    # Count asset files from fetch.txt
+    asset_count = 0
+    asset_total_bytes = 0
+    fetch_txt = bag_dir / "fetch.txt"
+    if fetch_txt.exists():
+        try:
+            with fetch_txt.open(encoding="utf-8") as f:
+                for line in f:
+                    parts_line = line.strip().split("\t")
+                    if len(parts_line) >= 2:
+                        asset_count += 1
+                        try:
+                            asset_total_bytes += int(parts_line[1])
+                        except ValueError:
+                            pass
+        except Exception:
+            pass
+
+    return {
+        "dataset_rid": dataset_rid,
+        "checksum": checksum[:12] + "...",
+        "checksum_full": checksum,
+        "size_bytes": size_bytes,
+        "size": _human_readable_size(size_bytes),
+        "asset_count": asset_count,
+        "asset_total_bytes": asset_total_bytes,
+        "asset_size": _human_readable_size(asset_total_bytes),
+        "materialized": materialized,
+        "description": description,
+        "modified": mtime.isoformat(),
+        "path": str(entry_path),
+    }
+
+
 def register_storage_tools(mcp_server: FastMCP, conn_manager: ConnectionManager):
     """Register storage management tools with the MCP server."""
 
     @mcp_server.tool()
-    def clear_cache(older_than_days: int | None = None) -> str:
+    async def list_cache_contents(
+        cache_dirs: list[str] | None = None,
+    ) -> str:
+        """List all cached dataset bags across all DerivaML cache directories.
+
+        Discovers cache directories automatically by scanning ~/.deriva-ml/
+        and the connected catalog's cache. Shows each cached bag with its
+        dataset RID, description, size, asset count, and materialization status.
+
+        Use this to understand what's consuming disk space before deciding
+        what to delete.
+
+        Args:
+            cache_dirs: Optional additional cache directory paths to scan.
+                These are added to the automatically discovered directories.
+
+        Returns:
+            JSON with:
+                - cache_directories: list of discovered cache paths with entry counts
+                - entries: list of cached bags, each with dataset_rid, checksum,
+                  size, asset_count, materialized, description, modified, path
+                - total_size: human-readable total size
+                - total_size_bytes: total size in bytes
+        """
+        try:
+            # Get connected catalog's cache dir if available
+            connected_cache = None
+            try:
+                ml = conn_manager.get_active_or_raise()
+                connected_cache = str(ml.cache_dir)
+            except Exception:
+                pass  # Not connected, just scan defaults
+
+            dirs = _discover_cache_dirs(connected_cache, cache_dirs)
+
+            all_entries: list[dict[str, Any]] = []
+            dir_summaries: list[dict[str, Any]] = []
+
+            for cache_dir in dirs:
+                entries_in_dir = []
+                for entry in sorted(cache_dir.iterdir()):
+                    if entry.is_dir() and "_" in entry.name:
+                        parsed = _parse_cache_entry(entry)
+                        if parsed:
+                            parsed["cache_dir"] = str(cache_dir)
+                            entries_in_dir.append(parsed)
+
+                # Derive hostname/catalog from the cache dir path
+                # Pattern: ~/.deriva-ml/{hostname}/{catalog_id}/cache
+                cache_parts = cache_dir.parts
+                label = str(cache_dir)
+                try:
+                    cache_idx = cache_parts.index("cache")
+                    if cache_idx >= 2:
+                        label = f"{cache_parts[cache_idx - 2]}/{cache_parts[cache_idx - 1]}"
+                except (ValueError, IndexError):
+                    pass
+
+                dir_summaries.append({
+                    "path": str(cache_dir),
+                    "label": label,
+                    "entry_count": len(entries_in_dir),
+                    "total_bytes": sum(e["size_bytes"] for e in entries_in_dir),
+                    "total_size": _human_readable_size(
+                        sum(e["size_bytes"] for e in entries_in_dir)
+                    ),
+                })
+                all_entries.extend(entries_in_dir)
+
+            total_bytes = sum(e["size_bytes"] for e in all_entries)
+
+            return json.dumps({
+                "status": "success",
+                "cache_directories": dir_summaries,
+                "entries": all_entries,
+                "total_entries": len(all_entries),
+                "total_size_bytes": total_bytes,
+                "total_size": _human_readable_size(total_bytes),
+            })
+        except Exception as e:
+            logger.error(f"Failed to list cache contents: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    @mcp_server.tool()
+    async def delete_cache_entry(
+        dataset_rid: str,
+        cache_dir: str | None = None,
+        confirm: bool = False,
+    ) -> str:
+        """Delete cached dataset bags for a specific dataset RID.
+
+        Finds and removes all cached bags matching the given dataset RID.
+        A single dataset may have multiple cached versions (different checksums).
+
+        IMPORTANT: This permanently deletes cached data. The bags can be
+        re-downloaded from the catalog but this may take significant time
+        for large datasets. Always call list_cache_contents first to review
+        what will be deleted.
+
+        Args:
+            dataset_rid: The dataset RID to delete cached bags for.
+                All cached versions of this dataset will be removed.
+            cache_dir: Optional specific cache directory to delete from.
+                If not provided, searches all discovered cache directories.
+            confirm: Must be set to true to actually delete. If false,
+                returns what would be deleted without removing anything
+                (dry run).
+
+        Returns:
+            JSON with deleted entries and bytes freed, or dry run preview.
+        """
+        try:
+            import shutil
+
+            connected_cache = None
+            try:
+                ml = conn_manager.get_active_or_raise()
+                connected_cache = str(ml.cache_dir)
+            except Exception:
+                pass
+
+            search_dirs = (
+                [Path(cache_dir)] if cache_dir else
+                _discover_cache_dirs(connected_cache)
+            )
+
+            matches: list[dict[str, Any]] = []
+            for d in search_dirs:
+                if not d.exists():
+                    continue
+                for entry in d.iterdir():
+                    if entry.is_dir() and entry.name.startswith(f"{dataset_rid}_"):
+                        parsed = _parse_cache_entry(entry)
+                        if parsed:
+                            matches.append(parsed)
+
+            if not matches:
+                return json.dumps({
+                    "status": "success",
+                    "message": f"No cached bags found for dataset {dataset_rid}",
+                    "entries_found": 0,
+                })
+
+            if not confirm:
+                return json.dumps({
+                    "status": "dry_run",
+                    "message": f"Found {len(matches)} cached bag(s) for dataset {dataset_rid}. "
+                               f"Set confirm=true to delete.",
+                    "entries": matches,
+                    "total_bytes": sum(e["size_bytes"] for e in matches),
+                    "total_size": _human_readable_size(
+                        sum(e["size_bytes"] for e in matches)
+                    ),
+                })
+
+            # Actually delete
+            deleted = []
+            errors = []
+            bytes_freed = 0
+            for entry in matches:
+                try:
+                    shutil.rmtree(entry["path"])
+                    deleted.append(entry)
+                    bytes_freed += entry["size_bytes"]
+                except Exception as e:
+                    errors.append({"path": entry["path"], "error": str(e)})
+
+            return json.dumps({
+                "status": "success",
+                "deleted": deleted,
+                "entries_deleted": len(deleted),
+                "bytes_freed": bytes_freed,
+                "size_freed": _human_readable_size(bytes_freed),
+                "errors": errors,
+            })
+        except Exception as e:
+            logger.error(f"Failed to delete cache entry: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    @mcp_server.tool()
+    async def clear_cache(
+        older_than_days: int | None = None,
+        cache_dir: str | None = None,
+        confirm: bool = False,
+    ) -> str:
         """Clear the dataset cache directory.
 
         Removes cached dataset bags to free disk space. Can optionally
         filter by age to only remove old entries.
 
+        IMPORTANT: This permanently deletes cached data. Always call
+        list_cache_contents first to review what will be removed, and
+        set confirm=true to proceed.
+
         Args:
             older_than_days: If provided, only remove cache entries older
                 than this many days. If None, removes all cache entries.
+            cache_dir: Optional specific cache directory to clear. If not
+                provided, clears the connected catalog's cache directory.
+            confirm: Must be set to true to actually delete. If false,
+                returns a preview of what would be deleted (dry run).
 
         Returns:
-            JSON object with:
-            - files_removed: Number of files removed
-            - dirs_removed: Number of directories removed
-            - bytes_freed: Total bytes freed
-            - errors: Number of removal errors
-
-        Example:
-            clear_cache()  # Clear all cache
-            clear_cache(older_than_days=7)  # Only clear old entries
+            JSON with deletion results or dry run preview.
         """
         try:
-            ml = conn_manager.get_active_or_raise()
-            result = ml.clear_cache(older_than_days=older_than_days)
+            if cache_dir:
+                target = Path(cache_dir)
+            else:
+                ml = conn_manager.get_active_or_raise()
+                target = ml.cache_dir
+
+            if not target.exists():
+                return json.dumps({
+                    "status": "success",
+                    "message": "Cache directory does not exist or is empty.",
+                    "entries_found": 0,
+                })
+
+            # Gather entries that would be affected
+            import time
+            cutoff_time = None
+            if older_than_days is not None:
+                cutoff_time = time.time() - (older_than_days * 24 * 60 * 60)
+
+            entries_to_delete: list[dict[str, Any]] = []
+            for entry in sorted(target.iterdir()):
+                if not entry.is_dir():
+                    continue
+                if cutoff_time is not None:
+                    if entry.stat().st_mtime > cutoff_time:
+                        continue
+                parsed = _parse_cache_entry(entry)
+                if parsed:
+                    entries_to_delete.append(parsed)
+
+            if not entries_to_delete:
+                return json.dumps({
+                    "status": "success",
+                    "message": "No cache entries match the criteria.",
+                    "entries_found": 0,
+                })
+
+            total_bytes = sum(e["size_bytes"] for e in entries_to_delete)
+
+            if not confirm:
+                return json.dumps({
+                    "status": "dry_run",
+                    "message": f"Found {len(entries_to_delete)} cache entry/entries "
+                               f"({_human_readable_size(total_bytes)}). "
+                               f"Set confirm=true to delete.",
+                    "older_than_days": older_than_days,
+                    "entries": entries_to_delete,
+                    "total_bytes": total_bytes,
+                    "total_size": _human_readable_size(total_bytes),
+                })
+
+            # Actually delete
+            import shutil
+            deleted = []
+            errors = []
+            bytes_freed = 0
+            for entry_info in entries_to_delete:
+                try:
+                    shutil.rmtree(entry_info["path"])
+                    deleted.append(entry_info)
+                    bytes_freed += entry_info["size_bytes"]
+                except Exception as e:
+                    errors.append({"path": entry_info["path"], "error": str(e)})
+
             return json.dumps({
                 "status": "success",
                 "older_than_days": older_than_days,
-                **result,
+                "entries_deleted": len(deleted),
+                "bytes_freed": bytes_freed,
+                "size_freed": _human_readable_size(bytes_freed),
+                "deleted": deleted,
+                "errors": errors,
             })
         except Exception as e:
             logger.error(f"Failed to clear cache: {e}")
             return json.dumps({"status": "error", "message": str(e)})
 
     @mcp_server.tool()
-    def clean_execution_dirs(
+    async def clean_execution_dirs(
         older_than_days: int | None = None,
         exclude_rids: list[str] | None = None,
+        confirm: bool = False,
     ) -> str:
         """Clean up execution working directories.
 
         Removes execution output directories from the local working directory
         to free disk space. Use this to clean up completed or orphaned executions.
 
+        IMPORTANT: This permanently deletes execution outputs that have not
+        been uploaded. Set confirm=true to proceed.
+
         Args:
             older_than_days: If provided, only remove directories older than
                 this many days. If None, removes all (except excluded).
             exclude_rids: List of execution RIDs to preserve (never remove).
+            confirm: Must be set to true to actually delete. If false,
+                returns a preview of what would be deleted (dry run).
 
         Returns:
-            JSON object with:
-            - dirs_removed: Number of directories removed
-            - bytes_freed: Total bytes freed
-            - errors: Number of removal errors
-
-        Example:
-            clean_execution_dirs()  # Clean all
-            clean_execution_dirs(older_than_days=30)  # Clean old only
-            clean_execution_dirs(exclude_rids=["1-ABC", "1-DEF"])  # Preserve specific
+            JSON with deletion results or dry run preview.
         """
         try:
             ml = conn_manager.get_active_or_raise()
+
+            if not confirm:
+                # Dry run: list what would be deleted
+                all_dirs = ml.list_execution_dirs()
+                exclude_set = set(exclude_rids or [])
+
+                import time
+                cutoff_time = None
+                if older_than_days is not None:
+                    cutoff_time = time.time() - (older_than_days * 24 * 60 * 60)
+
+                would_delete = []
+                for d in all_dirs:
+                    if d["execution_rid"] in exclude_set:
+                        continue
+                    if cutoff_time is not None:
+                        from datetime import datetime
+                        d_mtime = d["modified"].timestamp() if isinstance(d["modified"], datetime) else 0
+                        if d_mtime > cutoff_time:
+                            continue
+                    would_delete.append({
+                        "execution_rid": d["execution_rid"],
+                        "size": _human_readable_size(d["size_bytes"]),
+                        "size_bytes": d["size_bytes"],
+                        "modified": d["modified"].isoformat() if hasattr(d["modified"], "isoformat") else str(d["modified"]),
+                        "file_count": d["file_count"],
+                    })
+
+                total_bytes = sum(d["size_bytes"] for d in would_delete)
+                return json.dumps({
+                    "status": "dry_run",
+                    "message": f"Found {len(would_delete)} execution dir(s) "
+                               f"({_human_readable_size(total_bytes)}). "
+                               f"Set confirm=true to delete.",
+                    "entries": would_delete,
+                    "total_bytes": total_bytes,
+                    "total_size": _human_readable_size(total_bytes),
+                })
+
             result = ml.clean_execution_dirs(
                 older_than_days=older_than_days,
                 exclude_rids=exclude_rids,
@@ -889,6 +1305,7 @@ def register_storage_tools(mcp_server: FastMCP, conn_manager: ConnectionManager)
                 "older_than_days": older_than_days,
                 "exclude_rids": exclude_rids,
                 **result,
+                "size_freed": _human_readable_size(result.get("bytes_freed", 0)),
             })
         except Exception as e:
             logger.error(f"Failed to clean execution dirs: {e}")

--- a/src/deriva_mcp/tools/execution.py
+++ b/src/deriva_mcp/tools/execution.py
@@ -595,6 +595,7 @@ def register_execution_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> N
         version: str,
         materialize: bool = True,
         exclude_tables: list[str] | None = None,
+        timeout: list[int] | None = None,
     ) -> str:
         """Download a dataset version as a BDBag for use in this execution.
 
@@ -616,6 +617,9 @@ def register_execution_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> N
             exclude_tables: Optional list of table names to exclude from FK path
                 traversal during bag export. Use when downloads are slow or
                 timing out due to expensive joins through large tables.
+            timeout: Optional [connect_timeout, read_timeout] in seconds for
+                network requests. Default is [10, 610]. Increase read_timeout
+                for large datasets with deep FK joins that need more time.
 
         Returns:
             JSON with bag attributes: dataset_rid, version, description,
@@ -636,6 +640,7 @@ def register_execution_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> N
                 version=version,
                 materialize=materialize,
                 exclude_tables=set(exclude_tables) if exclude_tables else None,
+                timeout=tuple(timeout) if timeout else None,
             )
             bag = execution.download_dataset_bag(spec)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1296,6 +1296,104 @@ class TestDownloadDataset:
 
 
 # =============================================================================
+# TestEstimateBagSize
+# =============================================================================
+
+
+class TestEstimateBagSize:
+    """Tests for the estimate_bag_size tool."""
+
+    @pytest.mark.asyncio
+    async def test_estimate_success(self, dataset_tools, mock_ml):
+        """Estimating bag size returns table breakdown and totals."""
+        mock_estimate = {
+            "tables": {
+                "Image": {"row_count": 100, "is_asset": True, "asset_bytes": 500_000_000},
+                "Subject": {"row_count": 20, "is_asset": False, "asset_bytes": 0},
+            },
+            "total_rows": 120,
+            "total_asset_bytes": 500_000_000,
+            "total_asset_size": "476.8 MB",
+        }
+        mock_ml.estimate_bag_size.return_value = mock_estimate
+
+        mock_spec_cls = MagicMock()
+        mock_spec_instance = MagicMock()
+        mock_spec_cls.return_value = mock_spec_instance
+
+        with patch("deriva_ml.dataset.aux_classes.DatasetSpec", mock_spec_cls):
+            result = await dataset_tools["estimate_bag_size"](
+                dataset_rid="DS-001",
+                version="1.0.0",
+            )
+
+        data = assert_success(result)
+        assert data["total_rows"] == 120
+        assert data["total_asset_bytes"] == 500_000_000
+        assert data["total_asset_size"] == "476.8 MB"
+        assert "Image" in data["tables"]
+        assert data["tables"]["Image"]["is_asset"] is True
+        assert data["tables"]["Image"]["asset_bytes"] == 500_000_000
+        assert data["tables"]["Subject"]["row_count"] == 20
+        mock_spec_cls.assert_called_once_with(
+            rid="DS-001", version="1.0.0", exclude_tables=None,
+        )
+        mock_ml.estimate_bag_size.assert_called_once_with(mock_spec_instance)
+
+    @pytest.mark.asyncio
+    async def test_estimate_with_exclude_tables(self, dataset_tools, mock_ml):
+        """Exclude tables are passed through to DatasetSpec."""
+        mock_ml.estimate_bag_size.return_value = {
+            "tables": {},
+            "total_rows": 0,
+            "total_asset_bytes": 0,
+            "total_asset_size": "0 B",
+        }
+
+        mock_spec_cls = MagicMock()
+        mock_spec_instance = MagicMock()
+        mock_spec_cls.return_value = mock_spec_instance
+
+        with patch("deriva_ml.dataset.aux_classes.DatasetSpec", mock_spec_cls):
+            result = await dataset_tools["estimate_bag_size"](
+                dataset_rid="DS-001",
+                version="1.0.0",
+                exclude_tables=["Study", "Protocol"],
+            )
+
+        data = assert_success(result)
+        mock_spec_cls.assert_called_once_with(
+            rid="DS-001", version="1.0.0", exclude_tables={"Study", "Protocol"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_estimate_error(self, dataset_tools, mock_ml):
+        """Errors are returned as error status."""
+        mock_ml.estimate_bag_size.side_effect = Exception("Version not found")
+
+        mock_spec_cls = MagicMock()
+        mock_spec_cls.return_value = MagicMock()
+
+        with patch("deriva_ml.dataset.aux_classes.DatasetSpec", mock_spec_cls):
+            result = await dataset_tools["estimate_bag_size"](
+                dataset_rid="DS-001",
+                version="99.0.0",
+            )
+
+        assert_error(result, expected_message="Version not found")
+
+    @pytest.mark.asyncio
+    async def test_estimate_not_connected(self, dataset_tools_disconnected):
+        """Returns error when no catalog is connected."""
+        result = await dataset_tools_disconnected["estimate_bag_size"](
+            dataset_rid="DS-001",
+            version="1.0.0",
+        )
+
+        assert_error(result, expected_message="No active catalog connection")
+
+
+# =============================================================================
 # TestDenormalizeDataset
 # =============================================================================
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1210,6 +1210,7 @@ class TestDownloadDataset:
         assert data["bag_path"] == "/tmp/bags/DS-001"
         mock_spec_cls.assert_called_once_with(
             rid="DS-001", version="1.0.0", materialize=True,
+            exclude_tables=None, timeout=None,
         )
         mock_ml.download_dataset_bag.assert_called_once_with(mock_spec_instance)
 
@@ -1240,6 +1241,7 @@ class TestDownloadDataset:
         assert data["status"] == "downloaded"
         mock_spec_cls.assert_called_once_with(
             rid="DS-001", version="1.0.0", materialize=False,
+            exclude_tables=None, timeout=None,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -27,6 +27,7 @@ Storage tools (sync):
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1561,156 +1562,177 @@ class TestListParentExecutions:
 
 
 # =============================================================================
-# TestClearCache (Storage tool - SYNC)
+# TestListCacheContents (Storage tool)
+# =============================================================================
+
+
+class TestListCacheContents:
+    """Tests for the list_cache_contents storage tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_cache_discovers_dirs(self, storage_tools, mock_ml):
+        """list_cache_contents discovers cache dirs and returns entries."""
+        mock_ml.cache_dir = Path("/tmp/test-cache")
+
+        with patch("deriva_mcp.tools.execution._discover_cache_dirs") as mock_discover:
+            mock_discover.return_value = []
+            result = await storage_tools["list_cache_contents"]()
+
+        data = assert_success(result)
+        assert data["total_entries"] == 0
+        assert data["total_size_bytes"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_cache_with_extra_dirs(self, storage_tools, mock_ml):
+        """list_cache_contents accepts extra cache directories."""
+        mock_ml.cache_dir = Path("/tmp/test-cache")
+
+        with patch("deriva_mcp.tools.execution._discover_cache_dirs") as mock_discover:
+            mock_discover.return_value = []
+            result = await storage_tools["list_cache_contents"](
+                cache_dirs=["/tmp/extra-cache"]
+            )
+
+        data = assert_success(result)
+        mock_discover.assert_called_once_with(
+            str(Path("/tmp/test-cache")), ["/tmp/extra-cache"]
+        )
+
+
+# =============================================================================
+# TestDeleteCacheEntry (Storage tool)
+# =============================================================================
+
+
+class TestDeleteCacheEntry:
+    """Tests for the delete_cache_entry storage tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_dry_run(self, storage_tools, mock_ml):
+        """delete_cache_entry without confirm returns dry run preview."""
+        mock_ml.cache_dir = Path("/tmp/test-cache")
+
+        with patch("deriva_mcp.tools.execution._discover_cache_dirs") as mock_discover:
+            mock_discover.return_value = []
+            result = await storage_tools["delete_cache_entry"](
+                dataset_rid="DS-001",
+            )
+
+        data = assert_success(result)
+        assert data["entries_found"] == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_no_connection_still_works(self, storage_tools_disconnected):
+        """delete_cache_entry works without connection (scans defaults)."""
+        with patch("deriva_mcp.tools.execution._discover_cache_dirs") as mock_discover:
+            mock_discover.return_value = []
+            result = await storage_tools_disconnected["delete_cache_entry"](
+                dataset_rid="DS-001",
+            )
+
+        data = assert_success(result)
+        assert data["entries_found"] == 0
+
+
+# =============================================================================
+# TestClearCache (Storage tool)
 # =============================================================================
 
 
 class TestClearCache:
-    """Tests for the clear_cache storage tool (sync)."""
+    """Tests for the clear_cache storage tool."""
 
-    def test_clear_cache_all(self, storage_tools, mock_ml):
-        """clear_cache removes all cache entries and returns summary."""
-        mock_ml.clear_cache.return_value = {
-            "files_removed": 15,
-            "dirs_removed": 3,
-            "bytes_freed": 1048576,
-            "errors": 0,
-        }
+    @pytest.mark.asyncio
+    async def test_clear_cache_dry_run(self, storage_tools, mock_ml):
+        """clear_cache without confirm returns dry run preview."""
+        mock_ml.cache_dir = Path("/tmp/test-cache")
 
-        result = storage_tools["clear_cache"]()
+        with patch.object(Path, "exists", return_value=False):
+            result = await storage_tools["clear_cache"]()
 
         data = assert_success(result)
-        assert data["status"] == "success"
-        assert data["older_than_days"] is None
-        assert data["files_removed"] == 15
-        assert data["dirs_removed"] == 3
-        assert data["bytes_freed"] == 1048576
-        assert data["errors"] == 0
-        mock_ml.clear_cache.assert_called_once_with(older_than_days=None)
+        assert data["entries_found"] == 0
 
-    def test_clear_cache_older_than(self, storage_tools, mock_ml):
-        """clear_cache with older_than_days only removes old entries."""
-        mock_ml.clear_cache.return_value = {
-            "files_removed": 5,
-            "dirs_removed": 1,
-            "bytes_freed": 512000,
-            "errors": 0,
-        }
+    @pytest.mark.asyncio
+    async def test_clear_cache_confirmed(self, storage_tools, mock_ml):
+        """clear_cache with confirm=True and empty cache succeeds."""
+        mock_ml.cache_dir = Path("/tmp/test-cache")
 
-        result = storage_tools["clear_cache"](older_than_days=7)
+        with patch.object(Path, "exists", return_value=False):
+            result = await storage_tools["clear_cache"](confirm=True)
 
         data = assert_success(result)
-        assert data["older_than_days"] == 7
-        assert data["files_removed"] == 5
-        mock_ml.clear_cache.assert_called_once_with(older_than_days=7)
+        assert data["entries_found"] == 0
 
-    def test_clear_cache_empty(self, storage_tools, mock_ml):
-        """clear_cache succeeds when cache is already empty."""
-        mock_ml.clear_cache.return_value = {
-            "files_removed": 0,
-            "dirs_removed": 0,
-            "bytes_freed": 0,
-            "errors": 0,
-        }
-
-        result = storage_tools["clear_cache"]()
-
-        data = assert_success(result)
-        assert data["files_removed"] == 0
-        assert data["bytes_freed"] == 0
-
-    def test_clear_cache_exception(self, storage_tools, mock_ml):
-        """clear_cache returns error when cache clearing fails."""
-        mock_ml.clear_cache.side_effect = Exception("Permission denied")
-
-        result = storage_tools["clear_cache"]()
-
-        assert_error(result, "Permission denied")
-
-    def test_clear_cache_no_connection(self, storage_tools_disconnected):
-        """clear_cache returns error when not connected."""
-        result = storage_tools_disconnected["clear_cache"]()
+    @pytest.mark.asyncio
+    async def test_clear_cache_no_connection(self, storage_tools_disconnected):
+        """clear_cache returns error when not connected and no cache_dir given."""
+        result = await storage_tools_disconnected["clear_cache"]()
 
         assert_error(result, "No active catalog connection")
 
+    @pytest.mark.asyncio
+    async def test_clear_cache_with_explicit_dir(self, storage_tools_disconnected):
+        """clear_cache works without connection when cache_dir is provided."""
+        with patch.object(Path, "exists", return_value=False):
+            result = await storage_tools_disconnected["clear_cache"](
+                cache_dir="/tmp/explicit-cache"
+            )
+
+        data = assert_success(result)
+        assert data["entries_found"] == 0
+
 
 # =============================================================================
-# TestCleanExecutionDirs (Storage tool - SYNC)
+# TestCleanExecutionDirs (Storage tool)
 # =============================================================================
 
 
 class TestCleanExecutionDirs:
-    """Tests for the clean_execution_dirs storage tool (sync)."""
+    """Tests for the clean_execution_dirs storage tool."""
 
-    def test_clean_dirs_all(self, storage_tools, mock_ml):
-        """clean_execution_dirs removes all execution directories."""
+    @pytest.mark.asyncio
+    async def test_clean_dirs_dry_run(self, storage_tools, mock_ml):
+        """clean_execution_dirs without confirm returns dry run preview."""
+        mock_ml.list_execution_dirs.return_value = []
+
+        result = await storage_tools["clean_execution_dirs"]()
+
+        data = json.loads(result)
+        assert data["status"] == "dry_run"
+
+    @pytest.mark.asyncio
+    async def test_clean_dirs_confirmed(self, storage_tools, mock_ml):
+        """clean_execution_dirs with confirm=True actually deletes."""
         mock_ml.clean_execution_dirs.return_value = {
             "dirs_removed": 5,
             "bytes_freed": 2097152,
             "errors": 0,
         }
 
-        result = storage_tools["clean_execution_dirs"]()
+        result = await storage_tools["clean_execution_dirs"](confirm=True)
 
         data = assert_success(result)
-        assert data["status"] == "success"
-        assert data["older_than_days"] is None
-        assert data["exclude_rids"] is None
         assert data["dirs_removed"] == 5
         assert data["bytes_freed"] == 2097152
-        assert data["errors"] == 0
         mock_ml.clean_execution_dirs.assert_called_once_with(
             older_than_days=None,
             exclude_rids=None,
         )
 
-    def test_clean_dirs_older_than(self, storage_tools, mock_ml):
-        """clean_execution_dirs with older_than_days only removes old dirs."""
-        mock_ml.clean_execution_dirs.return_value = {
-            "dirs_removed": 2,
-            "bytes_freed": 100000,
-            "errors": 0,
-        }
-
-        result = storage_tools["clean_execution_dirs"](older_than_days=30)
-
-        data = assert_success(result)
-        assert data["older_than_days"] == 30
-        mock_ml.clean_execution_dirs.assert_called_once_with(
-            older_than_days=30,
-            exclude_rids=None,
-        )
-
-    def test_clean_dirs_with_excludes(self, storage_tools, mock_ml):
-        """clean_execution_dirs excludes specified RIDs."""
-        mock_ml.clean_execution_dirs.return_value = {
-            "dirs_removed": 3,
-            "bytes_freed": 500000,
-            "errors": 0,
-        }
-
-        result = storage_tools["clean_execution_dirs"](
-            exclude_rids=["1-ABC", "1-DEF"]
-        )
-
-        data = assert_success(result)
-        assert data["exclude_rids"] == ["1-ABC", "1-DEF"]
-        mock_ml.clean_execution_dirs.assert_called_once_with(
-            older_than_days=None,
-            exclude_rids=["1-ABC", "1-DEF"],
-        )
-
-    def test_clean_dirs_with_both_params(self, storage_tools, mock_ml):
-        """clean_execution_dirs with both older_than_days and exclude_rids."""
+    @pytest.mark.asyncio
+    async def test_clean_dirs_with_params(self, storage_tools, mock_ml):
+        """clean_execution_dirs passes through older_than_days and exclude_rids."""
         mock_ml.clean_execution_dirs.return_value = {
             "dirs_removed": 1,
             "bytes_freed": 250000,
             "errors": 0,
         }
 
-        result = storage_tools["clean_execution_dirs"](
+        result = await storage_tools["clean_execution_dirs"](
             older_than_days=14,
             exclude_rids=["1-KEEP"],
+            confirm=True,
         )
 
         data = assert_success(result)
@@ -1721,44 +1743,19 @@ class TestCleanExecutionDirs:
             exclude_rids=["1-KEEP"],
         )
 
-    def test_clean_dirs_empty(self, storage_tools, mock_ml):
-        """clean_execution_dirs succeeds when no directories to clean."""
-        mock_ml.clean_execution_dirs.return_value = {
-            "dirs_removed": 0,
-            "bytes_freed": 0,
-            "errors": 0,
-        }
-
-        result = storage_tools["clean_execution_dirs"]()
-
-        data = assert_success(result)
-        assert data["dirs_removed"] == 0
-
-    def test_clean_dirs_with_errors(self, storage_tools, mock_ml):
-        """clean_execution_dirs reports partial cleanup with errors."""
-        mock_ml.clean_execution_dirs.return_value = {
-            "dirs_removed": 3,
-            "bytes_freed": 750000,
-            "errors": 2,
-        }
-
-        result = storage_tools["clean_execution_dirs"]()
-
-        data = assert_success(result)
-        assert data["dirs_removed"] == 3
-        assert data["errors"] == 2
-
-    def test_clean_dirs_exception(self, storage_tools, mock_ml):
+    @pytest.mark.asyncio
+    async def test_clean_dirs_exception(self, storage_tools, mock_ml):
         """clean_execution_dirs returns error when cleanup fails."""
-        mock_ml.clean_execution_dirs.side_effect = Exception("Disk error")
+        mock_ml.list_execution_dirs.side_effect = Exception("Disk error")
 
-        result = storage_tools["clean_execution_dirs"]()
+        result = await storage_tools["clean_execution_dirs"]()
 
         assert_error(result, "Disk error")
 
-    def test_clean_dirs_no_connection(self, storage_tools_disconnected):
+    @pytest.mark.asyncio
+    async def test_clean_dirs_no_connection(self, storage_tools_disconnected):
         """clean_execution_dirs returns error when not connected."""
-        result = storage_tools_disconnected["clean_execution_dirs"]()
+        result = await storage_tools_disconnected["clean_execution_dirs"]()
 
         assert_error(result, "No active catalog connection")
 


### PR DESCRIPTION
## Summary

- Expose configurable download timeout in `download_dataset` and `download_execution_dataset` MCP tools (previously hardcoded at 610s)
- Add `estimate_bag_size` tool to preview dataset bag contents (row counts, asset sizes) before downloading
- Add `list_cache_contents` and `delete_cache_entry` cache management tools
- Rewrite `clear_cache` and `clean_execution_dirs` with safe `confirm=False` dry-run defaults to prevent accidental data loss
- Update dataset skills documentation with timeout, exclude_tables, and estimation guidance

## Test plan

- [x] Existing download tests updated for new parameters
- [x] 4 tests for `estimate_bag_size` (success, exclude_tables, error, disconnected)
- [x] 13 tests for cache management tools (list, delete, clear, clean with dry-run/confirm variants)
- [x] All new tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)