### PR TITLE
Fix 31 skill documentation issues from v2 audit

### DIFF
--- a/plugin/skills/api-naming-conventions/SKILL.md
+++ b/plugin/skills/api-naming-conventions/SKILL.md
@@ -9,6 +9,8 @@ disable-model-invocation: true
 
 Consistent naming conventions for API methods ensure discoverability and predictable behavior. Use this reference when calling DerivaML tools or writing scripts.
 
+**Note**: This reference covers both MCP tools and Python API methods. Some methods listed here (e.g., `lookup_dataset`, `find_datasets`, `list_vocabulary_terms`, `list_tables`) exist only in the Python API, not as MCP tools. When working via MCP, use the corresponding resource or tool (e.g., `deriva://catalog/datasets` resource, `query_table` tool).
+
 ## Method Prefixes
 
 ### `lookup_*(identifier)` -- Single Entity by Identifier

--- a/plugin/skills/catalog-operations-workflow/references/script-patterns.md
+++ b/plugin/skills/catalog-operations-workflow/references/script-patterns.md
@@ -67,13 +67,12 @@ Create a new dataset and populate it with members.
 
 ```python
 with ml.create_execution(config, dry_run=args.dry_run) as execution:
-    dataset = ml.create_dataset(
+    dataset = execution.create_dataset(
         dataset_types=["Training"],
         description="Training dataset with 10,000 balanced images.",
     )
-    ml.add_dataset_members(dataset["RID"], "Image", member_rids)
-
-execution.upload_execution_outputs()
+    dataset.add_dataset_members(member_rids)
+    # Outputs auto-uploaded on context exit
 ```
 
 ---
@@ -83,16 +82,16 @@ execution.upload_execution_outputs()
 Split an existing dataset into train/val/test partitions with optional stratification.
 
 ```python
-with ml.create_execution(config, dry_run=args.dry_run) as execution:
-    splits = ml.split_dataset(
-        dataset_rid="1-ABC4",
-        test_size=0.1,
-        val_size=0.1,
-        stratify_by_column="Image_Classification_Image_Class",
-        seed=42,
-    )
+from deriva_ml.dataset.split import split_dataset
 
-execution.upload_execution_outputs()
+splits = split_dataset(
+    ml,
+    source_dataset_rid="1-ABC4",
+    test_size=0.1,
+    val_size=0.1,
+    stratify_by_column="Image_Classification_Image_Class",
+    seed=42,
+)
 ```
 
 ---

--- a/plugin/skills/coding-guidelines/SKILL.md
+++ b/plugin/skills/coding-guidelines/SKILL.md
@@ -39,21 +39,21 @@ uv add torch torchvision  # ML framework deps
 ```toml
 [project]
 name = "my-ml-project"
-version = "0.1.0"
-requires-python = ">=3.11"
+dynamic = ["version"]
+requires-python = ">=3.12"
 dependencies = [
     "deriva-ml>=0.5.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 jupyter = ["jupyterlab", "papermill"]
 dev = ["pytest", "ruff"]
 
-[dependency-groups]
-jupyter = ["jupyterlab", "papermill"]
+[tool.setuptools_scm]
+# Version derived from git tags
 
 [project.scripts]
-deriva-ml-run = "my_project.configs:main"
+load-my-data = "scripts.load_data:main"
 ```
 
 ## Environment Management

--- a/plugin/skills/configure-experiment/SKILL.md
+++ b/plugin/skills/configure-experiment/SKILL.md
@@ -17,6 +17,7 @@ This covers the structure of a DerivaML experiment project: config groups, how t
 | `assets` | Pre-trained weights, reference files | `configs/assets.py` |
 | `workflow` | What the code does | `configs/workflow.py` |
 | `model_config` | Hyperparameters and architecture | `configs/<model>.py` |
+| `notebook` | Notebook-specific configs | `configs/<notebook>.py` |
 | `experiment` | Named combinations of the above | `configs/experiments.py` |
 | `multiruns` | Sweeps over experiments/parameters | `configs/multiruns.py` |
 
@@ -80,16 +81,16 @@ Named multiruns are preferred because they're committed to the repo, self-docume
 
 For the full `multirun_config` API, see the `write-hydra-config` skill.
 
-## Update Experiments.md
+## Optional: Generate Experiments.md
 
-After adding or modifying experiment or multirun configs, regenerate `Experiments.md` in the project root. This file is a human-readable summary of all defined experiments — it should always reflect the current state of the config code.
+For projects with many experiments, consider maintaining an `Experiments.md` file in the project root as a human-readable summary of all defined experiments. This is optional but helpful for discoverability.
 
 1. **Read the config source** — `experiments.py`, `multiruns.py`, and any model config files they reference
 2. **Extract each experiment's** name, config group overrides, key parameters (epochs, lr, batch size, architecture), and purpose
 3. **Extract each multirun's** name, overrides, sweep ranges, and description
 4. **Write `Experiments.md`** with a quick-reference table, a multiruns table, and a detail section per experiment
 
-Include `Experiments.md` in the same commit as the config changes — it should travel with the code it describes.
+If maintained, include `Experiments.md` in the same commit as the config changes — it should travel with the code it describes.
 
 ### Format
 

--- a/plugin/skills/create-dataset/SKILL.md
+++ b/plugin/skills/create-dataset/SKILL.md
@@ -39,3 +39,4 @@ For the full step-by-step guide with code examples (both MCP tools and Python AP
 - **`prepare-training-data`** — Downloading, extracting, and preparing dataset data for ML training pipelines.
 - **`debug-bag-contents`** — Diagnosing missing data, FK traversal issues, and export problems in dataset bags.
 - **`dataset-versioning`** — Full versioning rules, semantic versioning conventions, and pre-experiment checklist.
+- **`run-ml-execution`** — Wrap dataset creation in an execution for provenance tracking.

--- a/plugin/skills/create-dataset/references/bags.md
+++ b/plugin/skills/create-dataset/references/bags.md
@@ -80,7 +80,7 @@ Use `materialize=False` when you only need the tabular data (record metadata, fe
 
 Bags are cached locally by checksum. When you download the same dataset version again, the cached bag is reused without re-downloading. The cache key is `{dataset_rid}_{checksum}`.
 
-The cache location can be configured via the `cache_dir` argument when creating a DerivaML instance. Use `list_cache_contents` to see cached bags and `clear_cache` or `delete_cache_entry` to manage cache.
+The cache location can be configured via the `cache_dir` argument when creating a DerivaML instance. Read the `deriva://storage/cache` resource to see cached bags, and use `clear_cache` to remove all cached data.
 
 ## Downloading a Bag
 

--- a/plugin/skills/create-feature/SKILL.md
+++ b/plugin/skills/create-feature/SKILL.md
@@ -27,7 +27,7 @@ For background on feature types, metadata columns, multivalued features, and fea
 2. `create_feature` — link a target table to vocabulary terms, assets, or both
 3. `create_execution` + `start_execution` — start provenance tracking
 4. `add_feature_value` / `add_feature_value_record` — assign values to records in batch
-5. `stop_execution` + `upload_execution_outputs` — finalize and upload staged feature values to the catalog
+5. `stop_execution` — finalize (feature values are written directly to the catalog by `add_feature_value`; `upload_execution_outputs` is only needed if you also registered file assets)
 
 For the full step-by-step guide with code examples (both MCP tools and Python API), see `references/workflow.md`.
 

--- a/plugin/skills/create-feature/references/workflow.md
+++ b/plugin/skills/create-feature/references/workflow.md
@@ -79,7 +79,7 @@ Feature values require an active execution for provenance tracking. Every label 
 - `entries`: list of dicts, each with `target_rid` plus column values matching the feature's schema
 - `execution_rid` (optional): defaults to the active execution
 
-**Step 3:** Call `stop_execution`, then call `upload_execution_outputs` to write the staged feature values to the catalog.
+**Step 3:** Call `stop_execution` to finalize. Feature values are written directly to the catalog by `add_feature_value` — no `upload_execution_outputs` call is needed unless you also registered file assets with `asset_file_path`.
 
 ### Python API with context manager
 
@@ -110,11 +110,8 @@ with ml.create_execution(config) as exe:
         records.append(RecordClass(Image=image_rid, Tumor_Grade=grade))
 
     # Add all records in batch (execution RID set automatically)
-    # Records are staged to JSONL on disk, not written to catalog yet
     exe.add_features(records)
-
-# Upload staged feature values to the catalog
-exe.upload_execution_outputs()
+    # Feature values are uploaded automatically on context exit
 ```
 
 ## Query Feature Values
@@ -173,7 +170,7 @@ Call `add_feature_value` with `table_name`: `"Image"`, `feature_name`: `"Cell_Cl
 - `{"target_rid": "2-IMG1", "value": "Epithelial"}`
 - `{"target_rid": "2-IMG2", "value": "Immune"}`
 
-Call `stop_execution`. Then call `upload_execution_outputs` to write the staged feature values to the catalog.
+Call `stop_execution` to finalize. Feature values were already written to the catalog by `add_feature_value`.
 
 ## Complete Example: Python API
 
@@ -209,7 +206,5 @@ with ml.create_execution(ExecutionConfiguration(workflow=workflow)) as exe:
         RecordClass(Image="2-IMG2", Cell_Type="Immune"),
     ]
     exe.add_features(records)
-
-# Upload staged feature values to catalog
-exe.upload_execution_outputs()
+    # Feature values are uploaded automatically on context exit
 ```

--- a/plugin/skills/create-table/references/workflow.md
+++ b/plugin/skills/create-table/references/workflow.md
@@ -108,14 +108,7 @@ create_asset_table(
         {"name": "Width", "type": "int4", "nullok": true, "comment": "Image width in pixels"},
         {"name": "Height", "type": "int4", "nullok": true, "comment": "Image height in pixels"}
     ],
-    foreign_keys=[
-        {
-            "column": "Sample",
-            "referenced_table": "Sample",
-            "on_delete": "CASCADE",
-            "comment": "The sample this slide image was taken from"
-        }
-    ],
+    referenced_tables=["Sample"],
     comment="Microscopy slide images of biological samples"
 )
 ```

--- a/plugin/skills/customize-display/SKILL.md
+++ b/plugin/skills/customize-display/SKILL.md
@@ -28,7 +28,7 @@ Use catalog resources to see the current state:
 
 ```
 # View table annotations and column details
-get_table(table_name="Image")
+# Read the deriva://table/Image/annotations resource
 
 # View sample data to understand what users see
 get_table_sample_data(table_name="Image", limit=5)
@@ -58,8 +58,6 @@ Annotations can be set per-context, controlling how data appears in different Ch
 ### Table display name
 ```
 set_table_display_name(table_name="Image", display_name="Images")
-# Or set it contextually
-set_display_annotation(table_name="Image", display_name="Images")
 ```
 
 ### Column display name
@@ -79,7 +77,7 @@ Control which columns appear and in what order for each context.
 
 ### View current visible columns
 ```
-get_table(table_name="Image")
+# Read the deriva://table/Image/annotations resource
 # Check the visible_columns annotation in the response
 ```
 

--- a/plugin/skills/dataset-versioning/SKILL.md
+++ b/plugin/skills/dataset-versioning/SKILL.md
@@ -45,7 +45,7 @@ After any such change:
 
 ## Rule 3: Always Provide Version Descriptions
 
-Version descriptions are required and must explain:
+Version descriptions are strongly recommended and should explain:
 - **What** changed in this version
 - **Why** the change was made
 - **Impact** on experiments or downstream usage

--- a/plugin/skills/debug-bag-contents/SKILL.md
+++ b/plugin/skills/debug-bag-contents/SKILL.md
@@ -24,8 +24,8 @@ Dataset members are the explicit records that belong to a dataset. If data is mi
 
 Every table that contributes members to a dataset must be registered as a **dataset element type**. If a table is not registered, its members will be silently excluded from the bag.
 
-- **Resource**: Check the dataset element types resource to see which tables are registered for this dataset type.
-- **Tool**: `add_dataset_element_type` to register a table as an element type if it is missing. You need to specify the dataset type and the table name.
+- **Resource**: Read `deriva://catalog/dataset-element-types` to see which tables are registered as element types in the catalog.
+- **Tool**: `add_dataset_element_type(table_name="...")` to register a table as an element type if it is missing.
 - Common tables that should be registered: `Subject`, `Observation`, `Image` (or other asset tables), and any custom tables whose records appear as dataset members.
 
 ---
@@ -97,7 +97,7 @@ The bag export algorithm uses foreign key (FK) path traversal to determine which
 
 **Fix**:
 - Vocabulary terms referenced by included records should be automatically exported. If they are missing, verify the FK relationship between the data table and the vocabulary table is intact.
-- **Tool**: `get_table` on the vocabulary table to confirm its structure.
+- Read `deriva://table/{vocab_table}/schema` to confirm the vocabulary table's structure.
 
 ---
 
@@ -238,4 +238,4 @@ Use this checklist when data is missing from a bag:
 | `download_dataset` | Download the dataset bag (supports `exclude_tables` and `timeout`) |
 | `denormalize_dataset` | Flatten dataset for analysis |
 | `query_table` | Inspect FK column values |
-| `get_table` | Check table schema and FK relationships |
+| `get_table` | Check table schema and FK relationships (or read `deriva://table/{name}/schema` resource) |

--- a/plugin/skills/generate-descriptions/SKILL.md
+++ b/plugin/skills/generate-descriptions/SKILL.md
@@ -14,7 +14,7 @@ Every catalog entity that accepts a description MUST have one. If the user doesn
 - **Executions and Workflows**: `create_execution`, Workflow configuration -- description parameter
 - **Features**: `create_feature` -- description parameter
 - **Vocabulary Terms**: `add_term` -- description parameter
-- **Tables and Columns**: `create_table`, `set_table_description`, `set_column_description`
+- **Tables and Columns**: `create_table` (uses `comment` parameter), `set_table_description`, `set_column_description`
 - **Assets**: asset metadata descriptions
 
 For hydra-zen configuration descriptions (`with_description()` and `zen_meta`), see the `write-hydra-config` skill.

--- a/plugin/skills/maintain-experiment-notes/SKILL.md
+++ b/plugin/skills/maintain-experiment-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintain-experiment-notes
-description: "ALWAYS use after any significant experiment decision — dataset creation, split strategy, feature selection, hyperparameter choice, architecture selection, or catalog structure change. Append the decision and rationale to experiment-decisions.md automatically."
+description: "ALWAYS use after any significant experiment decision — running a model or experiment, dataset creation, split strategy, feature selection, hyperparameter choice, architecture selection, catalog structure change, or interpreting experiment results. Append the decision and rationale to experiment-decisions.md automatically."
 user-invocable: false
 ---
 
@@ -20,6 +20,7 @@ Append an entry after any of these events:
 - **Split strategy**: Why this split ratio, why stratified, why patient-level vs image-level
 - **Feature selection**: Why this feature was created (or reused), what it represents, why this vocabulary
 - **Architecture/model choice**: Why this model, why these hyperparameters, what alternatives were considered
+- **Running experiments**: What was run, what the key results were, what was learned, what to try next
 - **Catalog structure changes**: Why a table was added/extended, why a column was added, why a FK was created
 - **Configuration choices**: Why this hydra-zen config, why these overrides, why this multirun setup
 - **Problem resolution**: What went wrong and why the chosen fix was correct (not just "fixed it")

--- a/plugin/skills/manage-vocabulary/SKILL.md
+++ b/plugin/skills/manage-vocabulary/SKILL.md
@@ -25,7 +25,7 @@ To **look up a specific term**, read the `deriva://vocabulary/{vocab_name}/{term
 
 Call `create_vocabulary` with:
 - `vocabulary_name`: table name in PascalCase with underscores (e.g., `"Tissue_Type"`)
-- `comment`: what this vocabulary classifies (e.g., `"Classification of biological tissue types for histology analysis"`)
+- `comment` (optional, recommended): what this vocabulary classifies (e.g., `"Classification of biological tissue types for histology analysis"`)
 
 This creates a table in the domain schema with the standard vocabulary columns.
 

--- a/plugin/skills/new-model/SKILL.md
+++ b/plugin/skills/new-model/SKILL.md
@@ -37,11 +37,12 @@ def my_model(
     batch_size: int = 64,
     hidden_size: int = 128,
     # Framework-injected (always last, always default None)
-    ml_instance: DerivaML = None,
+    ml_instance: DerivaML | None = None,
     execution: Execution | None = None,
 ) -> None:
     """Train my model on the provided datasets."""
-    # Load data from execution datasets
+    # execution.datasets returns DatasetBag objects (not Dataset)
+    # DatasetBag has: restructure_assets(), get_table_as_dict(), get_table_as_dataframe(), list_tables()
     for dataset in execution.datasets:
         dataset.restructure_assets(
             asset_table="Image",

--- a/plugin/skills/prepare-training-data/SKILL.md
+++ b/plugin/skills/prepare-training-data/SKILL.md
@@ -135,6 +135,41 @@ download_dataset(dataset_rid="2-XXXX", version="1.0.0")
 
 **When to use:** Production training pipelines, reproducible experiments, when you need actual files (not just URLs).
 
+### Restructure for ML Frameworks
+
+After downloading a dataset, use `restructure_assets` to organize files into the directory structure expected by ML frameworks (e.g., PyTorch ImageFolder):
+
+```
+restructure_assets(
+    dataset_rid="2-XXXX",
+    asset_table="Image",
+    output_dir="./ml_data",
+    group_by=["Diagnosis"],
+    version="1.0.0"
+)
+```
+
+This creates subdirectories by dataset type (Training/Testing) and group_by values:
+```
+./ml_data/
+  Training/
+    Normal/
+      image1.jpg
+    Abnormal/
+      image2.jpg
+  Testing/
+    Normal/
+      image3.jpg
+```
+
+**Parameters:**
+- `dataset_rid` (required): Dataset to restructure
+- `asset_table` (required): Table containing the assets (e.g., "Image")
+- `output_dir` (required): Where to create the directory structure
+- `group_by` (optional): Feature columns to group by (creates subdirectories)
+- `version` (optional): Dataset version
+- `use_symlinks` (optional, default true): Symlink instead of copying files
+
 ## Step 4: Use the Data
 
 ### Common Column Patterns

--- a/plugin/skills/query-catalog-data/SKILL.md
+++ b/plugin/skills/query-catalog-data/SKILL.md
@@ -15,17 +15,17 @@ This skill covers how to find, filter, and explore data in a Deriva catalog usin
 | `deriva://catalog/tables` | All tables with descriptions and row counts |
 | `deriva://catalog/schema` | Full schema with relationships |
 | `deriva://table/{name}/schema` | Column names, types, descriptions |
-| `deriva://table/{name}/sample` | Sample rows |
 | `deriva://table/{name}/features` | Features on a table |
 | `deriva://vocabulary/{name}` | Vocabulary terms |
 | `deriva://dataset/{rid}` | Dataset details and versions |
-| `deriva://chaise-url/{table}/{rid}` | Web UI link |
+| `deriva://chaise-url/{table_or_rid}` | Web UI link (pass table name or RID) |
 
 ## Key Tools
 
 | Tool | Purpose |
 |------|---------|
 | `query_table` | Query with filters, columns, limit/offset |
+| `get_table_sample_data` | Preview sample rows from a table |
 | `count_table` | Count matching records |
 | `get_record` | Fetch a single record by RID |
 | `validate_rids` | Check if RIDs exist |

--- a/plugin/skills/query-catalog-data/references/workflow.md
+++ b/plugin/skills/query-catalog-data/references/workflow.md
@@ -18,9 +18,8 @@ Read these MCP resources to get oriented:
 For a specific table:
 
 - `deriva://table/{table_name}/schema` -- Column names, types, nullability, and descriptions.
-- `deriva://table/{table_name}/sample` -- A few sample rows to understand the data shape.
 
-Use the `get_table` MCP tool for programmatic access to table metadata.
+Use `get_table_sample_data(table_name="...")` to preview sample rows.
 
 ## Simple Queries
 
@@ -94,13 +93,15 @@ get_record(table_name="Subject", rid="2-B4C8")
 
 This returns the complete record with all columns.
 
-### Resolve a RID
+### Validate Known RIDs
 
-Use the `validate_rids` MCP tool to check if RIDs exist and determine their table:
+Use `validate_rids` to check that dataset, asset, workflow, or execution RIDs exist before using them:
 
 ```
-validate_rids(rids=["2-B4C8", "2-D1E2"])
+validate_rids(dataset_rids=["2-B4C8"], asset_rids=["2-D1E2"])
 ```
+
+To resolve an unknown RID to its table, read the `deriva://rid/{rid}` resource instead.
 
 ## Query Related Data
 
@@ -127,7 +128,7 @@ query_table(table_name="Image", filters={"Subject": "2-A1B2"})
 Use the `download_dataset` MCP tool to get a complete local copy of a dataset:
 
 ```
-download_dataset(dataset_rid="2-B4C8", version=3)
+download_dataset(dataset_rid="2-B4C8", version="3")
 ```
 
 This downloads all dataset members and assets to a local directory.
@@ -215,14 +216,14 @@ To get data ready for ML training:
 1. **Identify the dataset**: `get_record(table_name="Dataset", rid="2-B4C8")`
 2. **Get the members**: `list_dataset_members(dataset_rid="2-B4C8")`
 3. **Denormalize**: `denormalize_dataset(dataset_rid="2-B4C8", include_tables=["Image", "Subject"])`
-4. **Download assets**: `download_dataset(dataset_rid="2-B4C8", version=3)`
+4. **Download assets**: `download_dataset(dataset_rid="2-B4C8", version="3")`
 
 ## Historical Queries with Versions
 
 Datasets in Deriva can be versioned. Query specific versions:
 
 ```
-download_dataset(dataset_rid="2-B4C8", version=3)
+download_dataset(dataset_rid="2-B4C8", version="3")
 ```
 
 To see available versions, read:
@@ -235,8 +236,7 @@ Always pin to a specific version for reproducible experiments.
 
 To get the Chaise (web UI) URL for any record, use the MCP resource:
 
-- `deriva://chaise-url/{table_name}/{rid}` -- Direct URL to view a record in the browser.
-- `deriva://chaise-url/{table_name}` -- URL to the table's record set view.
+- `deriva://chaise-url/{table_or_rid}` -- Pass a table name for the record set view, or a RID for a specific record.
 
 These URLs are useful for sharing records with collaborators or viewing complex relationships that are easier to navigate in the web interface.
 
@@ -258,9 +258,9 @@ Here is a typical workflow for exploring and extracting data from a catalog:
 
 7. **Check features**: Read `deriva://table/Image/features`, then `query_table(table_name="Image_Cell_Count", filters={"Image": "2-C3D4"})`.
 
-8. **Get dataset for ML**: `denormalize_dataset(dataset_rid="2-B4C8", include_tables=["Image", "Subject"])` for a flat view, or `download_dataset(dataset_rid="2-B4C8", version=3)` for a full local copy.
+8. **Get dataset for ML**: `denormalize_dataset(dataset_rid="2-B4C8", include_tables=["Image", "Subject"])` for a flat view, or `download_dataset(dataset_rid="2-B4C8", version="3")` for a full local copy.
 
-9. **Share with a colleague**: Read `deriva://chaise-url/Subject/2-A1B2` to get a shareable URL.
+9. **Share with a colleague**: Read `deriva://chaise-url/2-A1B2` to get a shareable URL for a specific record, or `deriva://chaise-url/Subject` for the table view.
 
 ## Asset Provenance
 

--- a/plugin/skills/run-experiment/SKILL.md
+++ b/plugin/skills/run-experiment/SKILL.md
@@ -54,8 +54,8 @@ uv run deriva-ml-run +experiment=baseline model_config.learning_rate=1e-2,1e-3,1
 
 After a run, check the execution was recorded:
 - Read `deriva://execution/{rid}` for details
-- Read `deriva://chaise-url/Execution/{rid}` for the web UI link
-- Verify: status is "Complete", correct datasets linked, output assets attached, git hash matches
+- Read `deriva://chaise-url/{rid}` for the web UI link
+- Verify: status is "Completed", correct datasets linked, output assets attached, git hash matches
 
 ## Reference Resources
 

--- a/plugin/skills/run-experiment/references/workflow.md
+++ b/plugin/skills/run-experiment/references/workflow.md
@@ -150,10 +150,10 @@ uv run deriva-ml-run +experiment=baseline model_config.learning_rate=0.01 dry_ru
 
 ### Running Sweeps (Multirun)
 
-For parameter sweeps defined with `multirun_config()`:
+For parameter sweeps defined with `multirun_config()` (no `--multirun` flag needed):
 
 ```bash
-uv run deriva-ml-run +experiment=lr_batch_sweep --multirun
+uv run deriva-ml-run +multirun=lr_batch_sweep
 ```
 
 For ad-hoc sweeps using Hydra's comma syntax:
@@ -174,7 +174,7 @@ uv run deriva-ml-run +experiment=baseline,long_training --multirun
 
 After the run completes, verify the execution was recorded. Use the MCP resource:
 
-- Read `deriva://executions` to list recent executions.
+- Read `deriva://catalog/executions` to list recent executions.
 - Read `deriva://execution/{rid}` for details on a specific execution.
 
 ### View in Chaise
@@ -185,10 +185,10 @@ Open the execution in the web interface. The Chaise URL is typically:
 https://{host}/chaise/record/#{catalog_id}/{schema}:Execution/RID={execution_rid}
 ```
 
-The MCP resource `deriva://chaise-url/Execution/{rid}` provides the direct URL.
+The MCP resource `deriva://chaise-url/{rid}` provides the direct URL (pass the execution RID).
 
 Verify:
-- The execution status is "Complete".
+- The execution status is "Completed".
 - The correct datasets and versions are linked.
 - Output assets and metrics are attached.
 - The git commit hash matches your expectation.
@@ -205,5 +205,5 @@ Verify:
 | `Dirty git state warning` | Uncommitted changes when running | Commit changes before running |
 | `Lock file out of date` | `uv.lock` does not match `pyproject.toml` | Run `uv lock` and commit |
 | `ModuleNotFoundError` | Dependencies not installed | Run `uv sync` |
-| `Multirun requires --multirun flag` | Using `multirun_config` without the flag | Add `--multirun` to the command |
+| `Multirun requires --multirun flag` | Ad-hoc sweep without the flag | Add `--multirun` for ad-hoc sweeps; named multiruns (`+multirun=X`) don't need it |
 | `dry_run output looks wrong` | Config resolution issue | Use `--info` to inspect the resolved config |

--- a/plugin/skills/run-ml-execution/SKILL.md
+++ b/plugin/skills/run-ml-execution/SKILL.md
@@ -42,11 +42,13 @@ config = ExecutionConfiguration(
     description="Train CNN on labeled images"
 )
 with ml.create_execution(config) as exe:
-    exe.download_execution_dataset()
+    # Datasets specified in config are auto-downloaded; access via exe.datasets
+    for dataset in exe.datasets:
+        dataset.restructure_assets(...)  # DatasetBag objects
     # ... do work ...
     path = exe.asset_file_path("Execution_Asset", "results.csv")
     # ... write to path ...
-exe.upload_execution_outputs()
+    # Outputs auto-uploaded on context exit
 ```
 
 ## Key Tools Beyond the Lifecycle
@@ -58,7 +60,7 @@ exe.upload_execution_outputs()
 - `add_nested_execution` — link parent and child executions for multi-step pipelines
 - `list_nested_executions` / `list_parent_executions` — navigate execution hierarchies
 - `create_execution_dataset` — create an output dataset linked to the active execution
-- `list_storage_contents` — find local execution working directories and cached datasets
+- `deriva://storage/execution-dirs` resource — find local execution working directories
 
 For the full step-by-step guide with all parameters, see `references/workflow.md`.
 

--- a/plugin/skills/run-ml-execution/references/concepts.md
+++ b/plugin/skills/run-ml-execution/references/concepts.md
@@ -258,14 +258,13 @@ The recommended Python pattern uses a `with` block:
 ```python
 with ml.create_execution(config) as exe:
     # On enter: creates execution record, sets status to Initializing → Running
-    exe.download_execution_dataset()
+    # Datasets specified in config are auto-downloaded
+    for dataset in exe.datasets:
+        dataset.restructure_assets(...)  # DatasetBag objects
     # ... do work ...
     path = exe.asset_file_path("Execution_Asset", "results.csv")
     # ... write to path ...
-    # On exit: sets status to Completed (or Failed on exception)
-
-# Upload AFTER exiting the with block
-exe.upload_execution_outputs()
+    # On exit: sets status to Completed (or Failed), outputs auto-uploaded
 ```
 
 **Key points:**
@@ -324,6 +323,6 @@ The restored execution becomes the active execution, so subsequent MCP tool call
 You need the execution's RID to restore it. Several ways to find it:
 
 - **From the catalog**: Read `deriva://execution/{execution_rid}` if you know the RID, or query the `Execution` table via `query_table` to search by workflow, status, or description.
-- **From local storage**: Call `list_storage_contents` with `filter`: `"executions"` to see execution working directories that still exist locally. Each entry includes the execution RID, a label, size, and modification time.
+- **From local storage**: Read the `deriva://storage/execution-dirs` resource to see execution working directories that still exist locally. Each entry includes the execution RID, a label, size, and modification time.
 - **From provenance**: Call `list_asset_executions` with an asset RID to find which execution produced it, or `list_dataset_executions` with a dataset RID to find executions that used it.
 - **From the web UI**: Browse executions in Chaise and copy the RID from the record page.

--- a/plugin/skills/run-ml-execution/references/workflow.md
+++ b/plugin/skills/run-ml-execution/references/workflow.md
@@ -119,9 +119,11 @@ config = ExecutionConfiguration(
 # 3. Run within context manager
 with ml.create_execution(config) as exe:
     # Execution auto-starts (status → Running)
+    # Datasets specified in config are auto-downloaded
 
-    # Download input datasets
-    exe.download_execution_dataset()
+    # Access downloaded datasets (DatasetBag objects)
+    for dataset in exe.datasets:
+        dataset.restructure_assets(...)
 
     # Do your work
     results = train_model(exe.working_dir)
@@ -131,9 +133,7 @@ with ml.create_execution(config) as exe:
     save_model(results, output_path)
 
     # Execution auto-stops on exit (status → Completed, or Failed on exception)
-
-# 4. Upload AFTER exiting the context manager
-exe.upload_execution_outputs()
+    # Outputs auto-uploaded on context exit
 ```
 
 **Key points:**
@@ -300,8 +300,9 @@ config = ExecutionConfiguration(
 )
 
 with ml.create_execution(config) as exe:
-    # Download datasets (auto-recorded as inputs)
-    exe.download_execution_dataset()
+    # Datasets auto-downloaded; access as DatasetBag objects
+    for dataset in exe.datasets:
+        dataset.restructure_assets(...)
 
     # Access working directory
     data_dir = exe.working_dir

--- a/plugin/skills/run-notebook/SKILL.md
+++ b/plugin/skills/run-notebook/SKILL.md
@@ -108,8 +108,8 @@ uv run deriva-ml-run-notebook notebooks/<notebook_name>.ipynb \
 
 ## MCP Tools
 
-- `inspect_notebook` — View notebook structure, parameters, and tags without running
-- `run_notebook` — Execute notebook with parameters and return execution RID
+- `inspect_notebook(notebook_path)` — View notebook structure, parameters, and tags without running
+- `run_notebook(notebook_path, config_name, dry_run, host, catalog_id)` — Execute notebook with parameters and return execution RID. The `config_name` selects the named config defined with `notebook_config()`. Use `host`/`catalog_id` to override the catalog connection.
 
 ## Pre-Production Checklist
 

--- a/plugin/skills/run-notebook/references/workflow.md
+++ b/plugin/skills/run-notebook/references/workflow.md
@@ -74,8 +74,9 @@ config = ExecutionConfiguration(
 )
 
 with ml.create_execution(config) as execution:
-    # Download data
-    execution.download_execution_dataset()
+    # Datasets specified in config are auto-downloaded
+    for dataset in execution.datasets:
+        dataset.restructure_assets(...)  # DatasetBag objects
 
     # Your training logic here
     model = train(execution.working_dir, learning_rate, batch_size, epochs)
@@ -87,8 +88,7 @@ with ml.create_execution(config) as execution:
     metrics_path = execution.asset_file_path("Execution_Asset", "metrics.json")
     save_metrics({"accuracy": 0.95, "loss": 0.12}, metrics_path)
 
-# Upload AFTER exiting the with block
-execution.upload_execution_outputs()
+    # Outputs auto-uploaded on context exit
 ```
 
 ### 5. Save Execution RID

--- a/plugin/skills/semantic-awareness/SKILL.md
+++ b/plugin/skills/semantic-awareness/SKILL.md
@@ -37,20 +37,20 @@ Use MCP resources to retrieve candidates. Which resources depend on the entity t
 
 **Tables:**
 ```
-deriva://catalog/schema          # All tables with columns and descriptions
-deriva://table/<name>/schema     # Specific table details
+deriva://catalog/schema                       # All tables with columns and descriptions
+deriva://table/{table_name}/schema            # Specific table details
 ```
 
 **Vocabulary terms:**
 ```
-deriva://vocabulary/<vocab_name>              # All terms with descriptions and synonyms
-deriva://vocabulary/<vocab_name>/<term_name>  # Lookup by name or synonym
+deriva://vocabulary/{vocab_name}              # All terms with descriptions and synonyms
+deriva://vocabulary/{vocab_name}/{term_name}  # Lookup by name or synonym
 ```
 
 **Features:**
 ```
-deriva://table/<table_name>/features          # Features on a target table
-deriva://feature/<table_name>/<feature_name>  # Feature details
+deriva://table/{table_name}/features          # Features on a target table
+deriva://feature/{table_name}/{feature_name}  # Feature details
 deriva://catalog/features                     # All features across all tables
 ```
 
@@ -146,7 +146,7 @@ See the `generate-descriptions` skill for templates and detailed guidance.
 
 **Tables**: "Subject" vs "Patient" vs "Participant" — these are often the same concept. Check column structure and record count, not just names. A table with 500 records and 5 FK relationships is worth extending, not duplicating.
 
-**Vocabulary terms**: Always search synonyms. "X-ray" might have synonym "Xray" or "radiograph". The right action is usually `add_synonym`, not `add_term`. Use the `deriva://vocabulary/<name>/<term>` resource which matches against synonyms automatically.
+**Vocabulary terms**: Always search synonyms. "X-ray" might have synonym "Xray" or "radiograph". The right action is usually `add_synonym`, not `add_term`. Use the `deriva://vocabulary/{vocab_name}/{term_name}` resource which matches against synonyms automatically.
 
 **Features**: A feature named "Quality" and one named "Image_Quality" on the same table are almost certainly duplicates. The combination of target table + vocabulary is the strongest duplicate signal. Check how many values already exist — a feature with thousands of values is definitely established.
 

--- a/plugin/skills/troubleshoot-execution/SKILL.md
+++ b/plugin/skills/troubleshoot-execution/SKILL.md
@@ -144,7 +144,7 @@ This guide covers common problems encountered when running DerivaML executions a
 **Solution**:
 - **Best practice**: Always use the context manager (`with ml.create_execution(config) as exe:`) which automatically handles cleanup on both success and failure.
 - To fix a stuck execution manually:
-  - **Tool**: `update_execution_status` with `status="Failed"` and `message="Manually marked as failed"` (or `status="Complete"` if the work actually finished).
+  - **Tool**: `update_execution_status` with `status="Failed"` and `message="Manually marked as failed"` (or `status="Completed"` if the work actually finished).
 - **Tool**: `get_execution_info` to inspect the execution's current state and metadata.
 - For future runs, always use the context manager to prevent this issue.
 
@@ -160,7 +160,7 @@ This guide covers common problems encountered when running DerivaML executions a
 - Check the relevant vocabulary resource to list existing terms.
 - Vocabulary term names are case-sensitive.
 - **Tool**: `add_term` to add the missing term to the appropriate vocabulary.
-- Common vocabularies: `Dataset_Type`, `Asset_Type`, `Workflow_Type`, `Execution_Status_Type`.
+- Common vocabularies: `Dataset_Type`, `Asset_Type`, `Workflow_Type`.
 
 ---
 
@@ -200,4 +200,4 @@ logging.basicConfig(level=logging.DEBUG)
   - No unexpected files or directory structures.
 
 ### Clean Up
-- **Tool**: `clean_execution_dirs` to remove local execution working directories that are no longer needed, freeing disk space.
+- **Resource**: Read `deriva://storage/execution-dirs` to list local execution working directories. Remove unneeded directories manually to free disk space.

--- a/plugin/skills/use-annotation-builders/references/builder-api.md
+++ b/plugin/skills/use-annotation-builders/references/builder-api.md
@@ -90,8 +90,8 @@ from deriva_ml.model.annotations import VisibleForeignKeys, CONTEXT_DETAILED
 vfk = VisibleForeignKeys()
 
 vfk.set(CONTEXT_DETAILED, [
-    {"source": [{"outbound": ["schema", "Image_Subject_fkey"]}, "RID"]},
-    {"source": [{"outbound": ["schema", "Sample_Subject_fkey"]}, "RID"]}
+    {"source": [{"inbound": ["schema", "Image_Subject_fkey"]}, "RID"]},
+    {"source": [{"inbound": ["schema", "Sample_Subject_fkey"]}, "RID"]}
 ])
 
 table.annotations[VisibleForeignKeys.tag] = vfk.to_dict()

--- a/plugin/skills/work-with-assets/SKILL.md
+++ b/plugin/skills/work-with-assets/SKILL.md
@@ -29,8 +29,9 @@ For background on asset tables, types, RIDs, Hatrac storage, caching, and proven
 ### Downloading assets
 
 1. `download_asset` — download a single asset by RID
-2. `download_execution_dataset` — download a dataset as a BDBag with all asset files (within an execution)
-3. `restructure_assets` — organize downloaded assets into ML-ready directory layouts
+2. `download_dataset` — download a dataset as a BDBag with all asset files (no execution required)
+3. `download_execution_dataset` — same as above but within an active execution (records the dataset as an input for provenance)
+4. `restructure_assets` — organize downloaded assets into ML-ready directory layouts
 
 ### Creating asset tables
 

--- a/plugin/skills/write-hydra-config/SKILL.md
+++ b/plugin/skills/write-hydra-config/SKILL.md
@@ -120,7 +120,7 @@ Descriptions are recorded in execution metadata and make experiments self-docume
 | `ml_schema` | `str` | `'deriva-ml'` | Schema name for ML tables |
 | `logging_level` | `int` | `WARNING` | Logging level for DerivaML |
 | `deriva_logging_level` | `int` | `WARNING` | Logging level for underlying Deriva libraries |
-| `credential` | `Any` | `None` | Auth credentials. `None` = retrieved automatically |
+| `credential` | `dict \| None` | `None` | Auth credentials. `None` = retrieved automatically |
 | `s3_bucket` | `str \| None` | `None` | S3 bucket URL for bag storage (e.g., `'s3://my-bucket'`). Enables MINID |
 | `use_minid` | `bool \| None` | `None` | Use MINID for bags. `None` = auto (True if `s3_bucket` set) |
 | `check_auth` | `bool` | `True` | Verify authentication on connection |
@@ -197,3 +197,8 @@ After any catalog-modifying action (create_dataset, split_dataset, increment_dat
 3. Offer to update configs if versions are stale or new entities should be added
 4. Present changes for approval before modifying files
 5. Remind the user to commit config changes before running experiments
+
+## Related Skills
+
+- **`dataset-versioning`** — Rules for version pinning, when to increment, and semantic versioning conventions for datasets.
+- **`configure-experiment`** — Project structure, config group composition, and experiment setup.


### PR DESCRIPTION
## Summary

- Fix 10 Critical, 15 Important, and 15 Minor findings from the script-generated skill audit v2
- Addresses three systemic issues: Python API/MCP tool confusion, stale reference files, and resource URI errors
- 31 skill files updated across 20 skills

### Critical fixes
- `exe.download_execution_dataset()` → `exe.datasets` pattern (run-ml-execution, run-notebook)
- `create_asset_table` `foreign_keys` → `referenced_tables` (create-table)
- `chaise-url` URI from 2-param to 1-param form (query-catalog-data, run-experiment)
- Remove nonexistent `/sample` resource and tools (`list_storage_contents`, `clean_execution_dirs`)
- Remove `upload_execution_outputs` from feature-only workflow (create-feature)
- Fix `credential` type, cache tool references, `DatasetBag` documentation

### Important fixes
- Add MCP vs Python API distinction (api-naming-conventions)
- Fix `set_display_annotation` example and `get_table` deprecation (customize-display)
- Fix Python API calls on wrong classes (catalog-operations-workflow)
- Fix `outbound` → `inbound` in VisibleForeignKeys (use-annotation-builders)
- Fix pyproject.toml template (coding-guidelines)
- Add `restructure_assets` docs (prepare-training-data)

### Minor fixes
- Standardize URI placeholders, fix status values, add cross-references
- Add notebook config group, make Experiments.md optional
- Add experiment runs to maintain-experiment-notes triggers

## Test plan

- [ ] Verify skill files render correctly in Claude Code
- [ ] Spot-check resource URIs match actual MCP resource templates
- [ ] Verify code examples use correct API signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)