### PR TITLE
Feature selectors, resources, RAG enrichment, and cache tools

### DIFF
--- a/src/deriva_mcp/rag/__init__.py
+++ b/src/deriva_mcp/rag/__init__.py
@@ -466,6 +466,7 @@ class RAGManager:
         hostname: str,
         catalog_id: str | int,
         vocabulary_terms: dict[str, list[dict[str, str]]] | None = None,
+        feature_details: dict[str, list[dict[str, Any]]] | None = None,
     ) -> dict[str, Any]:
         """Index a catalog's schema for RAG search.
 
@@ -480,6 +481,11 @@ class RAGManager:
             vocabulary_terms: Optional mapping of vocabulary table names to their
                 term lists. Included in the index so RAG can answer questions
                 about available vocabulary values.
+            feature_details: Optional mapping of table names to enriched feature
+                definitions (columns, descriptions, vocabulary references).
+                Included so RAG can answer "what features exist on Image?" and
+                "what columns does the Diagnosis feature have?" Feature visibility
+                is per-user — only features the connected user can see are indexed.
 
         Returns:
             Dict with indexing statistics.
@@ -495,6 +501,7 @@ class RAGManager:
             chunk_size_target=self._config.chunk_size_target,
             overlap_sentences=self._config.chunk_overlap_sentences,
             vocabulary_terms=vocabulary_terms,
+            feature_details=feature_details,
         )
 
     def find_schema_source(

--- a/src/deriva_mcp/rag/helpers.py
+++ b/src/deriva_mcp/rag/helpers.py
@@ -112,10 +112,13 @@ def trigger_schema_reindex(conn_info: ConnectionInfo | None) -> None:
                                     "value_columns": [],
                                 }
                                 for col in feat.term_columns:
-                                    col_info: dict[str, str] = {"name": col.name}
+                                    col_info: dict[str, Any] = {"name": col.name}
+                                    col_info["required"] = not getattr(col, "nullok", True)
                                     if hasattr(col, "comment") and col.comment:
                                         col_info["comment"] = col.comment
-                                    # Include the vocabulary terms for this column
+                                    if hasattr(col, "default") and col.default is not None:
+                                        col_info["default"] = str(col.default)
+                                    # Include the vocabulary table for this column
                                     if hasattr(col, "references") and col.references:
                                         for ref in col.references:
                                             vocab_table = ref.pk_table.name if hasattr(ref, "pk_table") else ""
@@ -124,13 +127,25 @@ def trigger_schema_reindex(conn_info: ConnectionInfo | None) -> None:
                                     detail["term_columns"].append(col_info)
                                 for col in feat.asset_columns:
                                     col_info = {"name": col.name}
+                                    col_info["required"] = not getattr(col, "nullok", True)
                                     if hasattr(col, "comment") and col.comment:
                                         col_info["comment"] = col.comment
+                                    if hasattr(col, "default") and col.default is not None:
+                                        col_info["default"] = str(col.default)
+                                    # Include the asset table reference
+                                    if hasattr(col, "references") and col.references:
+                                        for ref in col.references:
+                                            asset_table = ref.pk_table.name if hasattr(ref, "pk_table") else ""
+                                            if asset_table:
+                                                col_info["asset_table"] = asset_table
                                     detail["asset_columns"].append(col_info)
                                 for col in feat.value_columns:
                                     col_info = {"name": col.name}
+                                    col_info["required"] = not getattr(col, "nullok", True)
                                     if hasattr(col, "comment") and col.comment:
                                         col_info["comment"] = col.comment
+                                    if hasattr(col, "default") and col.default is not None:
+                                        col_info["default"] = str(col.default)
                                     if hasattr(col, "type") and col.type:
                                         col_info["type"] = str(col.type.typename) if hasattr(col.type, "typename") else str(col.type)
                                     detail["value_columns"].append(col_info)

--- a/src/deriva_mcp/rag/helpers.py
+++ b/src/deriva_mcp/rag/helpers.py
@@ -114,6 +114,8 @@ def trigger_schema_reindex(conn_info: ConnectionInfo | None) -> None:
                                 for col in feat.term_columns:
                                     col_info: dict[str, Any] = {"name": col.name}
                                     col_info["required"] = not getattr(col, "nullok", True)
+                                    if hasattr(col, "type") and col.type:
+                                        col_info["type"] = str(col.type.typename) if hasattr(col.type, "typename") else str(col.type)
                                     if hasattr(col, "comment") and col.comment:
                                         col_info["comment"] = col.comment
                                     if hasattr(col, "default") and col.default is not None:
@@ -128,6 +130,8 @@ def trigger_schema_reindex(conn_info: ConnectionInfo | None) -> None:
                                 for col in feat.asset_columns:
                                     col_info = {"name": col.name}
                                     col_info["required"] = not getattr(col, "nullok", True)
+                                    if hasattr(col, "type") and col.type:
+                                        col_info["type"] = str(col.type.typename) if hasattr(col.type, "typename") else str(col.type)
                                     if hasattr(col, "comment") and col.comment:
                                         col_info["comment"] = col.comment
                                     if hasattr(col, "default") and col.default is not None:

--- a/src/deriva_mcp/rag/helpers.py
+++ b/src/deriva_mcp/rag/helpers.py
@@ -92,11 +92,59 @@ def trigger_schema_reindex(conn_info: ConnectionInfo | None) -> None:
                             ]
                         except Exception:
                             pass
+            # Gather feature details for each table that has features
+            feature_details: dict[str, list[dict[str, Any]]] = {}
+            for schema_data in schemas.values():
+                tables = schema_data.get("tables", {})
+                for table_name, table_info in tables.items():
+                    features = table_info.get("features", [])
+                    if features:
+                        try:
+                            detailed = []
+                            for f_info in features:
+                                feat = ml.lookup_feature(table_name, f_info["name"])
+                                detail: dict[str, Any] = {
+                                    "name": f_info["name"],
+                                    "feature_table": f_info.get("feature_table", ""),
+                                    "comment": getattr(feat, "comment", "") or "",
+                                    "term_columns": [],
+                                    "asset_columns": [],
+                                    "value_columns": [],
+                                }
+                                for col in feat.term_columns:
+                                    col_info: dict[str, str] = {"name": col.name}
+                                    if hasattr(col, "comment") and col.comment:
+                                        col_info["comment"] = col.comment
+                                    # Include the vocabulary terms for this column
+                                    if hasattr(col, "references") and col.references:
+                                        for ref in col.references:
+                                            vocab_table = ref.pk_table.name if hasattr(ref, "pk_table") else ""
+                                            if vocab_table:
+                                                col_info["vocabulary"] = vocab_table
+                                    detail["term_columns"].append(col_info)
+                                for col in feat.asset_columns:
+                                    col_info = {"name": col.name}
+                                    if hasattr(col, "comment") and col.comment:
+                                        col_info["comment"] = col.comment
+                                    detail["asset_columns"].append(col_info)
+                                for col in feat.value_columns:
+                                    col_info = {"name": col.name}
+                                    if hasattr(col, "comment") and col.comment:
+                                        col_info["comment"] = col.comment
+                                    if hasattr(col, "type") and col.type:
+                                        col_info["type"] = str(col.type.typename) if hasattr(col.type, "typename") else str(col.type)
+                                    detail["value_columns"].append(col_info)
+                                detailed.append(detail)
+                            feature_details[table_name] = detailed
+                        except Exception as e:
+                            logger.debug(f"Could not gather feature details for {table_name}: {e}")
+
             schema_hash = compute_schema_hash(schema_info, vocab_terms)
             conn_info.schema_hash = schema_hash
             result = manager.index_catalog_schema(
                 schema_info, conn_info.hostname, conn_info.catalog_id,
                 vocabulary_terms=vocab_terms,
+                feature_details=feature_details,
             )
             status = result.get("status", "unknown")
             if status == "indexed":

--- a/src/deriva_mcp/rag/schema.py
+++ b/src/deriva_mcp/rag/schema.py
@@ -148,25 +148,34 @@ def _table_to_markdown(
 
             # Term columns (vocabulary-based values)
             for col in f.get("term_columns", []):
-                col_line = f"  - Term: **{col['name']}**"
+                req = "required" if col.get("required") else "optional"
+                col_line = f"  - Term: **{col['name']}** [{req}]"
                 if col.get("vocabulary"):
                     col_line += f" (vocabulary: {col['vocabulary']})"
+                if col.get("default"):
+                    col_line += f" [default: {col['default']}]"
                 if col.get("comment"):
                     col_line += f" — {col['comment']}"
                 feat_lines.append(col_line)
 
             # Asset columns
             for col in f.get("asset_columns", []):
-                col_line = f"  - Asset: **{col['name']}**"
+                req = "required" if col.get("required") else "optional"
+                col_line = f"  - Asset: **{col['name']}** [{req}]"
+                if col.get("asset_table"):
+                    col_line += f" (table: {col['asset_table']})"
                 if col.get("comment"):
                     col_line += f" — {col['comment']}"
                 feat_lines.append(col_line)
 
             # Value/metadata columns
             for col in f.get("value_columns", []):
-                col_line = f"  - Value: **{col['name']}**"
+                req = "required" if col.get("required") else "optional"
+                col_line = f"  - Value: **{col['name']}** [{req}]"
                 if col.get("type"):
                     col_line += f" ({col['type']})"
+                if col.get("default"):
+                    col_line += f" [default: {col['default']}]"
                 if col.get("comment"):
                     col_line += f" — {col['comment']}"
                 feat_lines.append(col_line)

--- a/src/deriva_mcp/rag/schema.py
+++ b/src/deriva_mcp/rag/schema.py
@@ -74,6 +74,7 @@ def _table_to_markdown(
     table_name: str,
     table_info: dict[str, Any],
     vocabulary_terms: list[dict[str, Any]] | None = None,
+    feature_details: list[dict[str, Any]] | None = None,
 ) -> str:
     """Render a single table as a markdown document.
 
@@ -85,6 +86,10 @@ def _table_to_markdown(
             ``Description``, and optionally ``Synonyms`` (list of strings).
             Included for vocabulary tables so RAG can answer
             "what values are available?" questions.
+        feature_details: Optional list of enriched feature dicts with
+            ``name``, ``comment``, ``term_columns``, ``asset_columns``,
+            ``value_columns``. Included so RAG can answer "what columns
+            does this feature have?" questions.
     """
     parts: list[str] = []
 
@@ -126,14 +131,56 @@ def _table_to_markdown(
             fk_lines.append(f"- {cols} → {ref} ({ref_cols})")
         parts.append("\n".join(fk_lines))
 
-    # Features
-    features = table_info.get("features", [])
-    if features:
+    # Features — use enriched details when available, fall back to basic schema info
+    if feature_details:
         parts.append("### Features")
         feat_lines = []
-        for f in features:
-            feat_lines.append(f"- **{f['name']}** (table: {f['feature_table']})")
+        for f in feature_details:
+            name = f.get("name", "")
+            comment = f.get("comment", "")
+            feat_table = f.get("feature_table", "")
+            header = f"- **{name}**"
+            if feat_table:
+                header += f" (table: {feat_table})"
+            if comment:
+                header += f" — {comment}"
+            feat_lines.append(header)
+
+            # Term columns (vocabulary-based values)
+            for col in f.get("term_columns", []):
+                col_line = f"  - Term: **{col['name']}**"
+                if col.get("vocabulary"):
+                    col_line += f" (vocabulary: {col['vocabulary']})"
+                if col.get("comment"):
+                    col_line += f" — {col['comment']}"
+                feat_lines.append(col_line)
+
+            # Asset columns
+            for col in f.get("asset_columns", []):
+                col_line = f"  - Asset: **{col['name']}**"
+                if col.get("comment"):
+                    col_line += f" — {col['comment']}"
+                feat_lines.append(col_line)
+
+            # Value/metadata columns
+            for col in f.get("value_columns", []):
+                col_line = f"  - Value: **{col['name']}**"
+                if col.get("type"):
+                    col_line += f" ({col['type']})"
+                if col.get("comment"):
+                    col_line += f" — {col['comment']}"
+                feat_lines.append(col_line)
+
         parts.append("\n".join(feat_lines))
+    else:
+        # Fall back to basic feature info from schema
+        features = table_info.get("features", [])
+        if features:
+            parts.append("### Features")
+            feat_lines = []
+            for f in features:
+                feat_lines.append(f"- **{f['name']}** (table: {f['feature_table']})")
+            parts.append("\n".join(feat_lines))
 
     # Vocabulary terms (for vocabulary tables)
     if vocabulary_terms:
@@ -157,6 +204,7 @@ def _table_to_markdown(
 def schema_to_markdown(
     schema_info: dict[str, Any],
     vocabulary_terms: dict[str, list[dict[str, Any]]] | None = None,
+    feature_details: dict[str, list[dict[str, Any]]] | None = None,
 ) -> str:
     """Convert a full catalog schema description to a markdown document.
 
@@ -167,11 +215,15 @@ def schema_to_markdown(
             ``Synonyms`` keys). Vocabulary terms are included in the
             markdown so RAG can answer questions like "what diagnosis
             types exist?"
+        feature_details: Optional mapping of ``table_name`` to enriched
+            feature definitions with columns, descriptions, and vocabulary
+            references.
 
     Returns:
         A single markdown string covering all tables.
     """
     vocab_terms = vocabulary_terms or {}
+    feat_details = feature_details or {}
     parts: list[str] = []
 
     domain_schemas = schema_info.get("domain_schemas", [])
@@ -185,7 +237,8 @@ def schema_to_markdown(
         tables = schema_data.get("tables", {})
         for table_name, table_info in sorted(tables.items()):
             terms = vocab_terms.get(table_name)
-            parts.append(_table_to_markdown(schema_name, table_name, table_info, terms))
+            features = feat_details.get(table_name)
+            parts.append(_table_to_markdown(schema_name, table_name, table_info, terms, features))
 
     return "\n\n".join(parts)
 
@@ -235,6 +288,7 @@ def index_catalog_schema(
     chunk_size_target: int = 800,
     overlap_sentences: int = 1,
     vocabulary_terms: dict[str, list[dict[str, Any]]] | None = None,
+    feature_details: dict[str, list[dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
     """Index a catalog schema into the RAG collection.
 
@@ -253,6 +307,8 @@ def index_catalog_schema(
         vocabulary_terms: Optional mapping of vocabulary table names to their
             term lists (each term has ``Name``, ``Description``, and
             optionally ``Synonyms``).
+        feature_details: Optional mapping of table names to enriched feature
+            definitions with columns, descriptions, and vocabulary references.
 
     Returns:
         Dict with indexing statistics.
@@ -272,7 +328,7 @@ def index_catalog_schema(
     _remove_schema_chunks(collection, source)
 
     # Convert to markdown and chunk
-    markdown = schema_to_markdown(schema_info, vocabulary_terms=vocabulary_terms)
+    markdown = schema_to_markdown(schema_info, vocabulary_terms=vocabulary_terms, feature_details=feature_details)
     chunks = chunk_markdown(
         markdown,
         chunk_size_target=chunk_size_target,

--- a/src/deriva_mcp/resources.py
+++ b/src/deriva_mcp/resources.py
@@ -1105,6 +1105,90 @@ multirun_config(
             return json.dumps({"error": str(e)})
 
     @mcp.resource(
+        "deriva://table/{table_name}/feature-values/first",
+        name="Table Feature Values (First)",
+        description="Feature values for a table, deduplicated to earliest (first) annotation per target object",
+        mime_type="application/json",
+    )
+    def get_table_feature_values_first(table_name: str) -> str:
+        """Return feature values deduplicated to the earliest per target object.
+
+        When an object has multiple values for the same feature, this selects
+        the value with the earliest creation time (by RCT). Useful for preserving
+        original annotations and ignoring later revisions.
+        """
+        ml = conn_manager.get_active_or_raise()
+        if ml is None:
+            return json.dumps({"error": "No active catalog connection"})
+
+        try:
+            from deriva_ml.feature import FeatureRecord
+
+            features = ml.fetch_table_features(table_name, selector=FeatureRecord.select_first)
+            result = {fname: [r.model_dump(mode="json") for r in records] for fname, records in features.items()}
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @mcp.resource(
+        "deriva://table/{table_name}/feature-values/majority_vote",
+        name="Table Feature Values (Majority Vote)",
+        description="Feature values for a table, deduplicated to consensus (majority vote) label per target object",
+        mime_type="application/json",
+    )
+    def get_table_feature_values_majority_vote(table_name: str) -> str:
+        """Return feature values deduplicated by majority vote per target object.
+
+        For each feature, counts values per target object and selects the most
+        common one. Ties are broken by most recent RCT. For features with multiple
+        term columns, auto-detection may fail — use the fetch_table_features tool
+        with selector="majority_vote" and feature_name for explicit control.
+        """
+        ml = conn_manager.get_active_or_raise()
+        if ml is None:
+            return json.dumps({"error": "No active catalog connection"})
+
+        try:
+            from collections import defaultdict
+
+            from deriva_ml.feature import FeatureRecord
+
+            features = ml.fetch_table_features(table_name)
+            result = {}
+            for fname, records in features.items():
+                if not records:
+                    result[fname] = []
+                    continue
+                RecordClass = type(records[0])
+                try:
+                    selector = RecordClass.select_majority_vote()
+                except Exception:
+                    # Auto-detection failed (multi-term feature) — fall back to newest
+                    selector = FeatureRecord.select_newest
+
+                feat = ml.lookup_feature(table_name, fname)
+                target_col = feat.target_table.name
+                grouped: dict[str, list] = defaultdict(list)
+                for r in records:
+                    target_rid = getattr(r, target_col, None)
+                    if target_rid is not None:
+                        grouped[target_rid].append(r)
+
+                selected = []
+                for group in grouped.values():
+                    if len(group) == 1:
+                        selected.append(group[0])
+                    else:
+                        try:
+                            selected.append(selector(group))
+                        except Exception:
+                            selected.append(FeatureRecord.select_newest(group))
+                result[fname] = [r.model_dump(mode="json") for r in selected]
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @mcp.resource(
         "deriva://vocabulary/{vocab_name}",
         name="Vocabulary Terms",
         description="Terms in a specific vocabulary table",

--- a/src/deriva_mcp/server.py
+++ b/src/deriva_mcp/server.py
@@ -143,6 +143,11 @@ Always call `connect_catalog` before using other tools. This establishes the con
 - `deriva://table/{table}/feature-values/first` - One per record (earliest)
 - `deriva://table/{table}/feature-values/majority_vote` - One per record (consensus)
 
+**Before running an experiment (pre-flight checklist):**
+1. `validate_rids` - Verify all dataset and asset RIDs exist and versions are valid
+2. `bag_info` - Check dataset sizes and local cache status
+3. `cache_dataset` - Download datasets/assets into local cache ahead of time (no execution needed)
+
 **Running workflows:**
 1. `create_execution` - Start a tracked execution
 2. `start_execution` / `stop_execution` - Manage execution lifecycle

--- a/src/deriva_mcp/server.py
+++ b/src/deriva_mcp/server.py
@@ -120,11 +120,28 @@ Always call `connect_catalog` before using other tools. This establishes the con
 3. `list_dataset_members` - View dataset contents
 4. `split_dataset` - Create train/test splits with optional stratification
 5. `download_dataset` - Download dataset assets locally
-6. `restructure_assets` - Organize downloaded assets into ML-ready directories
+6. `restructure_assets` - Organize downloaded assets into ML-ready directories (supports `value_selector` for multi-annotator data)
 
 **Adding features:**
 1. `create_feature` - Define a new feature linking a target table to vocabulary terms
 2. `add_feature_value` or `add_feature_value_record` - Assign feature values to records
+3. `fetch_table_features` - Query feature values with deduplication selectors
+
+**Feature value selection** (for resolving multiple values per record):
+- `selector="newest"` - Most recent annotation (default choice)
+- `selector="first"` - Earliest annotation (preserve originals)
+- `selector="latest"` - Alias for newest
+- `selector="majority_vote"` - Consensus label (requires `feature_name`)
+- `workflow="Training"` - Filter by workflow type name or RID
+- `execution="3-XYZ"` - Filter by specific execution RID
+- Only one selection method at a time (mutually exclusive)
+
+**Feature value resources** (pre-deduplicated, no tool call needed):
+- `deriva://catalog/features` - All feature definitions
+- `deriva://table/{table}/feature-values` - All values (raw, no dedup)
+- `deriva://table/{table}/feature-values/newest` - One per record (most recent)
+- `deriva://table/{table}/feature-values/first` - One per record (earliest)
+- `deriva://table/{table}/feature-values/majority_vote` - One per record (consensus)
 
 **Running workflows:**
 1. `create_execution` - Start a tracked execution

--- a/src/deriva_mcp/tools/dataset.py
+++ b/src/deriva_mcp/tools/dataset.py
@@ -931,6 +931,161 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             return json.dumps({"status": "error", "message": str(e)})
 
     @mcp.tool()
+    async def bag_info(
+        dataset_rid: str,
+        version: str,
+        exclude_tables: list[str] | None = None,
+    ) -> str:
+        """Get comprehensive info about a dataset bag: size, contents, and cache status.
+
+        Combines the size estimate (row counts, asset sizes per table) with
+        local cache status. Use this to decide whether to prefetch a bag
+        before running an experiment.
+
+        Cache status values:
+        - "not_cached": No local copy exists
+        - "cached_metadata_only": Table data downloaded, assets not fetched
+        - "cached_materialized": Fully downloaded and validated
+        - "cached_incomplete": Was cached but some assets are missing
+
+        Args:
+            dataset_rid: RID of the dataset to inspect.
+            version: Semantic version to inspect (e.g., "1.0.0").
+            exclude_tables: Optional list of table names to exclude from FK
+                path traversal.
+
+        Returns:
+            JSON with size info (tables, total_rows, total_asset_bytes,
+            total_asset_size) plus cache_status and cache_path.
+        """
+        try:
+            from deriva_ml.dataset.aux_classes import DatasetSpec
+
+            ml = conn_manager.get_active_or_raise()
+            spec = DatasetSpec(
+                rid=dataset_rid,
+                version=version,
+                exclude_tables=set(exclude_tables) if exclude_tables else None,
+            )
+            info = ml.bag_info(spec)
+            return json.dumps({"status": "success"} | info)
+        except Exception as e:
+            logger.error(f"Failed to get bag info: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    @mcp.tool()
+    async def cache_dataset(
+        dataset_rid: str | None = None,
+        asset_rid: str | None = None,
+        version: str | None = None,
+        materialize: bool = True,
+        exclude_tables: list[str] | None = None,
+    ) -> str:
+        """Download a dataset bag or asset into the local cache without creating an execution.
+
+        Use this to warm the cache before running experiments. No execution or
+        provenance records are created — this is purely a local download
+        operation. After prefetching, subsequent download_dataset or
+        download_execution_dataset calls will use the cached copy.
+
+        Provide either dataset_rid (for bags) or asset_rid (for individual
+        assets), not both.
+
+        Args:
+            dataset_rid: RID of a dataset to prefetch (mutually exclusive with asset_rid).
+            asset_rid: RID of an asset to prefetch (mutually exclusive with dataset_rid).
+            version: Dataset version to prefetch (required when using dataset_rid).
+            materialize: If True (default), download all asset files in the bag.
+                If False, download only table metadata (faster, smaller).
+                Ignored for asset prefetch.
+            exclude_tables: Optional list of table names to exclude from FK
+                path traversal during bag export. Only applies to dataset prefetch.
+
+        Returns:
+            JSON with prefetch results. For datasets: bag_info including
+            cache_status and size. For assets: file path and metadata.
+        """
+        try:
+            ml = conn_manager.get_active_or_raise()
+
+            if dataset_rid and asset_rid:
+                return json.dumps({
+                    "status": "error",
+                    "message": "Provide either dataset_rid or asset_rid, not both.",
+                })
+
+            if dataset_rid:
+                if not version:
+                    dataset = ml.lookup_dataset(dataset_rid)
+                    version = str(dataset.current_version)
+
+                from deriva_ml.dataset.aux_classes import DatasetSpec
+                spec = DatasetSpec(
+                    rid=dataset_rid,
+                    version=version,
+                    materialize=materialize,
+                    exclude_tables=set(exclude_tables) if exclude_tables else None,
+                )
+                result = ml.prefetch_dataset(spec, materialize=materialize)
+                return json.dumps({"status": "success", "type": "dataset"} | result)
+
+            elif asset_rid:
+                # Download asset to cache without provenance
+                from pathlib import Path
+                cache_dir = ml.cache_dir / "assets"
+                cache_dir.mkdir(parents=True, exist_ok=True)
+
+                # Resolve the asset to get its metadata
+                asset_table = ml.resolve_rid(asset_rid).table
+                asset_record = ml.retrieve_rid(asset_rid)
+                asset_url = asset_record.get("URL")
+                filename = asset_record.get("Filename", "unknown")
+                md5 = asset_record.get("MD5")
+
+                # Check cache first
+                if md5:
+                    cache_key = f"{asset_rid}_{md5}"
+                    cached_file = cache_dir / cache_key / filename
+                    if cached_file.exists():
+                        return json.dumps({
+                            "status": "success",
+                            "type": "asset",
+                            "cache_status": "cached",
+                            "file_path": str(cached_file),
+                            "asset_table": asset_table.name if hasattr(asset_table, "name") else str(asset_table),
+                            "filename": filename,
+                        })
+
+                # Download the asset
+                asset_dest = cache_dir / f"{asset_rid}_{md5 or 'nomd5'}"
+                asset_dest.mkdir(parents=True, exist_ok=True)
+                dest_file = asset_dest / filename
+
+                from deriva.core import get_credential
+                hostname = ml.catalog.deriva_server.server
+                credentials = get_credential(hostname)
+                from bdbag.fetch.fetcher import fetch_single_file
+                fetch_single_file(asset_url, output_path=dest_file)
+
+                return json.dumps({
+                    "status": "success",
+                    "type": "asset",
+                    "cache_status": "cached",
+                    "file_path": str(dest_file),
+                    "asset_table": asset_table.name if hasattr(asset_table, "name") else str(asset_table),
+                    "filename": filename,
+                })
+
+            else:
+                return json.dumps({
+                    "status": "error",
+                    "message": "Provide either dataset_rid or asset_rid.",
+                })
+        except Exception as e:
+            logger.error(f"Failed to cache dataset: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    @mcp.tool()
     async def validate_dataset_bag(
         dataset_rid: str,
         version: str | None = None,

--- a/src/deriva_mcp/tools/dataset.py
+++ b/src/deriva_mcp/tools/dataset.py
@@ -1218,6 +1218,7 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
         enforce_vocabulary: bool = True,
         version: str | None = None,
         materialize: bool = True,
+        value_selector: str | None = None,
     ) -> str:
         """Restructure dataset assets into a directory hierarchy for ML workflows.
 
@@ -1282,6 +1283,11 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             version: Specific dataset version to download (default: current).
             materialize: If True (default), download all asset files. If False,
                 only download metadata (assets won't be available for restructuring).
+            value_selector: How to resolve conflicts when an asset has multiple
+                values for a feature. Supported: "newest", "first", "latest",
+                "majority_vote". If not provided, raises an error when multiple
+                different values exist (with enforce_vocabulary=True) or uses
+                the first value found (with enforce_vocabulary=False).
 
         Returns:
             JSON with status, output_dir path, and count of restructured assets.
@@ -1351,6 +1357,40 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             spec = DatasetSpec(rid=dataset_rid, version=version, materialize=materialize)
             bag = ml.download_dataset_bag(spec)
 
+            # Resolve value_selector string to callable
+            selector_fn = None
+            if value_selector:
+                from deriva_ml.feature import FeatureRecord
+
+                if value_selector == "newest":
+                    selector_fn = FeatureRecord.select_newest
+                elif value_selector == "first":
+                    selector_fn = FeatureRecord.select_first
+                elif value_selector == "latest":
+                    selector_fn = FeatureRecord.select_latest
+                elif value_selector == "majority_vote":
+                    # For restructure, majority_vote needs column info from the feature
+                    # Auto-detection will happen inside _load_feature_values_cache
+                    # We need to look up the feature to get the record class
+                    if group_by:
+                        feature_name = group_by[0].split(".")[0] if "." in group_by[0] else group_by[0]
+                        try:
+                            feat = bag.lookup_feature(asset_table, feature_name)
+                            RecordClass = feat.feature_record_class()
+                            selector_fn = RecordClass.select_majority_vote()
+                        except Exception:
+                            selector_fn = FeatureRecord.select_majority_vote(None)
+                    else:
+                        return json.dumps({
+                            "status": "error",
+                            "message": "value_selector='majority_vote' requires group_by to be specified.",
+                        })
+                else:
+                    return json.dumps({
+                        "status": "error",
+                        "message": f"Unknown value_selector '{value_selector}'. Supported: 'newest', 'first', 'latest', 'majority_vote'.",
+                    })
+
             # Restructure the assets
             file_map = bag.restructure_assets(
                 asset_table=asset_table,
@@ -1358,6 +1398,7 @@ def register_dataset_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
                 group_by=group_by or [],
                 use_symlinks=use_symlinks,
                 enforce_vocabulary=enforce_vocabulary,
+                value_selector=selector_fn,
             )
 
             # file_map is a dict[Path, Path] mapping source -> dest

--- a/src/deriva_mcp/tools/feature.py
+++ b/src/deriva_mcp/tools/feature.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -297,7 +297,22 @@ def register_feature_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             )
         except Exception as e:
             logger.error(f"Failed to add feature values: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            error_msg = str(e)
+            result: dict[str, Any] = {"status": "error", "message": error_msg}
+
+            # Suggest alternatives when feature or table not found
+            from deriva_mcp.rag.helpers import _is_not_found_error, rag_suggest_entity
+            if _is_not_found_error(error_msg):
+                conn_info = conn_manager.get_active_connection_info()
+                # Try suggesting the feature name first, then the table name
+                suggestions = rag_suggest_entity(feature_name, conn_info)
+                if not suggestions:
+                    suggestions = rag_suggest_entity(table_name, conn_info)
+                if suggestions:
+                    result["suggestions"] = suggestions
+                    result["hint"] = f"Did you mean: {suggestions[0]['name']}?"
+
+            return json.dumps(result)
 
     @mcp.tool()
     async def add_feature_value_record(
@@ -403,7 +418,21 @@ def register_feature_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             )
         except Exception as e:
             logger.error(f"Failed to add feature value records: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            error_msg = str(e)
+            result: dict[str, Any] = {"status": "error", "message": error_msg}
+
+            # Suggest alternatives when feature or table not found
+            from deriva_mcp.rag.helpers import _is_not_found_error, rag_suggest_entity
+            if _is_not_found_error(error_msg):
+                conn_info = conn_manager.get_active_connection_info()
+                suggestions = rag_suggest_entity(feature_name, conn_info)
+                if not suggestions:
+                    suggestions = rag_suggest_entity(table_name, conn_info)
+                if suggestions:
+                    result["suggestions"] = suggestions
+                    result["hint"] = f"Did you mean: {suggestions[0]['name']}?"
+
+            return json.dumps(result)
 
     @mcp.tool()
     async def fetch_table_features(
@@ -560,7 +589,12 @@ def register_feature_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             from deriva_mcp.rag.helpers import _is_not_found_error, rag_suggest_entity
             if _is_not_found_error(error_msg):
                 conn_info = conn_manager.get_active_connection_info()
-                suggestions = rag_suggest_entity(table_name, conn_info)
+                # Try feature_name first (more specific), then table_name
+                suggestions = None
+                if feature_name:
+                    suggestions = rag_suggest_entity(feature_name, conn_info)
+                if not suggestions:
+                    suggestions = rag_suggest_entity(table_name, conn_info)
                 if suggestions:
                     result["suggestions"] = suggestions
                     result["hint"] = f"Did you mean: {suggestions[0]['name']}?"

--- a/src/deriva_mcp/tools/feature.py
+++ b/src/deriva_mcp/tools/feature.py
@@ -440,7 +440,8 @@ def register_feature_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             table_name: Table to fetch features for (e.g., "Image", "Subject").
             feature_name: If provided, only fetch this specific feature.
                 If not provided, fetches all features on the table.
-            selector: Built-in selector name. Currently supported: "newest".
+            selector: Built-in selector name. Supported: "newest", "first",
+                "latest", "majority_vote" (requires feature_name).
                 Picks one value per target object using the most recent RCT.
             workflow: Workflow RID or Workflow_Type name. Filters values to those
                 produced by executions of the matching workflow, then picks the
@@ -485,11 +486,26 @@ def register_feature_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> Non
             selector_fn = None
             if selector == "newest":
                 selector_fn = FeatureRecord.select_newest
+            elif selector == "first":
+                selector_fn = FeatureRecord.select_first
+            elif selector == "latest":
+                selector_fn = FeatureRecord.select_latest
+            elif selector == "majority_vote":
+                if not feature_name:
+                    return json.dumps(
+                        {
+                            "status": "error",
+                            "message": "selector='majority_vote' requires feature_name to be specified.",
+                        }
+                    )
+                feat = ml.lookup_feature(table_name, feature_name)
+                RecordClass = feat.feature_record_class()
+                selector_fn = RecordClass.select_majority_vote()
             elif selector is not None:
                 return json.dumps(
                     {
                         "status": "error",
-                        "message": f"Unknown selector '{selector}'. Supported: 'newest'.",
+                        "message": f"Unknown selector '{selector}'. Supported: 'newest', 'first', 'latest', 'majority_vote'.",
                     }
                 )
 


### PR DESCRIPTION
## Summary

- Expand `fetch_table_features` selectors: `first`, `latest`, `majority_vote`
- Add `value_selector` parameter to `restructure_assets` tool
- Add `feature-values/first` and `feature-values/majority_vote` MCP resources
- Add `bag_info` and `cache_dataset` MCP tools for pre-flight cache management
- Enrich RAG index with feature column details (required/optional, types, defaults, vocabulary refs)
- Add RAG suggestions to all feature tools on not-found errors
- Update server instructions with new selectors, resources, and pre-flight checklist

## Test plan

- [x] 23/23 feature tool tests pass
- [x] 27/27 RAG schema tests pass
- [x] 6/6 restructure tests pass
- [x] 484/485 full test suite (1 pre-existing failure in test_execution)
- [ ] Integration test with updated deriva-ml

🤖 Generated with [Claude Code](https://claude.com/claude-code)