### PR TITLE
v2.0 migration: commit_output_assets (deriva-ml#224 companion)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ def register_*_tools(mcp: FastMCP, conn_manager: ConnectionManager) -> None:
 | workflow.py | Workflow registration | create_workflow, find_workflows |
 | feature.py | Feature definitions | create_feature, find_features, list_feature_values |
 | schema.py | Schema management | create_table, create_asset_table |
-| execution.py | ML execution lifecycle | create_execution, start_execution, upload_execution_outputs |
+| execution.py | ML execution lifecycle | create_execution, start_execution, commit_output_assets |
 | data.py | Data queries | query_table, insert_records |
 | devtools.py | Dev utilities | bump_version, start_app, list_apps, stop_app, run_notebook |
 

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ Found configuration files in configs/:
 | `get_execution_info` | Get details about the active execution |
 | `restore_execution` | Restore a previous execution by RID |
 | `asset_file_path` | Register a file for upload as an execution output |
-| `upload_execution_outputs` | Upload all registered outputs to the catalog |
+| `commit_output_assets` | Commit all registered outputs to the catalog |
 | `list_executions` | List recent executions |
 | `create_execution_dataset` | Create a dataset within an execution |
 | `download_execution_dataset` | Download a dataset for processing |
@@ -640,8 +640,8 @@ with execution.execute() as exe:
     exe.asset_file_path(asset_name="Image", file_name="output.png")
     # ... more processing ...
 
-# After context exits, upload outputs
-execution.upload_execution_outputs()
+# After context exits, commit output assets
+execution.commit_output_assets()
 ```
 
 Using MCP tools, the equivalent workflow is:
@@ -650,10 +650,10 @@ Using MCP tools, the equivalent workflow is:
 2. `start_execution()` - Mark execution as running, begin timing
 3. `asset_file_path()` - Register output files (repeat as needed)
 4. `stop_execution()` - Mark execution as complete
-5. `upload_execution_outputs()` - **Required**: Upload all registered files to catalog
+5. `commit_output_assets()` - **Required**: Commit all registered files to catalog
 
-**Important**: You must call `upload_execution_outputs()` after completing your work
-to upload any registered assets to the catalog. This is not automatic.
+**Important**: You must call `commit_output_assets()` after completing your work
+to commit any registered assets to the catalog. This is not automatic.
 
 ## Available Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.2.0",
-    "deriva-ml @ git+https://github.com/informatics-isi-edu/deriva-ml.git",
+    "deriva-ml>=2.0,<3.0",
     "pydantic>=2.0",
     "pip-system-certs>=5.3",
     "kaggle>=1.8.3",

--- a/src/deriva_mcp/connection.py
+++ b/src/deriva_mcp/connection.py
@@ -367,7 +367,7 @@ class ConnectionManager:
                     # Upload outputs if requested
                     if upload_outputs:
                         try:
-                            conn_info.execution.upload_execution_outputs(clean_folder=True)
+                            conn_info.execution.commit_output_assets(clean_folder=True)
                             logger.info(f"Uploaded MCP execution outputs for {key}")
                         except Exception as e:
                             logger.warning(f"Failed to upload execution outputs: {e}")

--- a/src/deriva_mcp/prompts.py
+++ b/src/deriva_mcp/prompts.py
@@ -1322,7 +1322,7 @@ with ml.create_execution(config) as exe:
     ]
     exe.add_features(bulk_records)
 
-exe.upload_execution_outputs()
+exe.commit_output_assets()
 ```
 
 ## Step 5: Query Feature Values
@@ -2135,7 +2135,7 @@ with ml.create_execution(config) as exe:
         }
     )
 
-exe.upload_execution_outputs()
+exe.commit_output_assets()
 ```
 
 ### MCP Tools
@@ -2943,7 +2943,7 @@ For uploading outputs, downloading datasets, and registering asset files, use th
 
 1. **Every execution needs a workflow** — Create or find one with `create_workflow` first.
 2. **Use the context manager in Python** — `with ml.create_execution(config) as exe:` auto-starts and auto-stops.
-3. **Upload AFTER the with block** — `exe.upload_execution_outputs()` must be called after exiting the context manager, never inside it.
+3. **Commit AFTER the with block** — `exe.commit_output_assets()` must be called after exiting the context manager, never inside it.
 4. **Use `exe.asset_file_path()` for all outputs** — This both creates the path and registers the file as an output asset. Never manually place files in the working directory.
 5. **Failed executions are tracked** — If an exception occurs in the with block, status is set to "Failed" automatically.
 
@@ -2960,7 +2960,7 @@ with ml.create_execution(config) as exe:
     # ... do work ...
     path = exe.asset_file_path("results.csv", description="Model predictions")
     # ... write to path ...
-exe.upload_execution_outputs()
+exe.commit_output_assets()
 ```
 
 ## MCP Tools
@@ -3040,13 +3040,13 @@ with ml.create_execution(config) as exe:
     save_metrics(results, metrics_path)
 
 # 4. Upload AFTER exiting the context manager
-exe.upload_execution_outputs()
+exe.commit_output_assets()
 ```
 
 **Key points about the context manager:**
 - `with` block automatically calls `start_execution()` on entry and `stop_execution()` on exit.
 - If an exception occurs inside the block, the execution status is set to "Failed".
-- You MUST call `upload_execution_outputs()` AFTER exiting the `with` block, not inside it.
+- You MUST call `commit_output_assets()` AFTER exiting the `with` block, not inside it.
 - Use `asset_file_path()` to register output files -- this both creates the file path and registers it as an output asset.
 
 ## MCP Tools Workflow
@@ -3076,8 +3076,8 @@ Step 4: Do your work
 Step 5: Stop the execution
   -> stop_execution(execution_rid="2-YYYY")
 
-Step 6: Upload outputs
-  Use the DerivaML Python API: exe.upload_execution_outputs()
+Step 6: Commit output assets
+  Use the DerivaML Python API: exe.commit_output_assets()
 ```
 
 ## ExecutionConfiguration Details
@@ -3192,7 +3192,7 @@ This creates the table with standard asset columns (URL, Filename, Length, MD5, 
 ## Tips
 
 - Always wrap work in an execution for provenance tracking.
-- Upload outputs AFTER the `with` block exits, never inside it (Python API: `exe.upload_execution_outputs()`).
+- Commit output assets AFTER the `with` block exits, never inside it (Python API: `exe.commit_output_assets()`).
 - Use `exe.asset_file_path()` (Python API) for every output file -- do not manually place files in the working directory.
 - Set meaningful descriptions on workflows, executions, and output assets.
 - For long-running work, use `update_execution_status()` to track progress.
@@ -4517,7 +4517,7 @@ def main():
     with ml.create_execution(config, dry_run=args.dry_run) as execution:
         # Perform operations
         ...
-        execution.upload_execution_outputs()
+        execution.commit_output_assets()
 
 if __name__ == "__main__":
     main()
@@ -4527,7 +4527,7 @@ Key elements:
 - `argparse` for CLI arguments
 - `--dry-run` flag for testing without side effects
 - `ExecutionConfiguration` context manager for provenance tracking
-- `execution.upload_execution_outputs()` to record results
+- `execution.commit_output_assets()` to record results
 
 ### 2. Test with Dry Run
 
@@ -4571,7 +4571,7 @@ with ml.create_execution(config, dry_run=args.dry_run) as execution:
         description="Training dataset with 10,000 balanced images.",
     )
     execution.add_dataset_members(dataset.rid, member_rids)
-    execution.upload_execution_outputs()
+    execution.commit_output_assets()
 ```
 
 ### Dataset Splitting
@@ -4584,7 +4584,7 @@ with ml.create_execution(config, dry_run=args.dry_run) as execution:
         stratify_by="Diagnosis",
         group_by="Subject",
     )
-    execution.upload_execution_outputs()
+    execution.commit_output_assets()
 ```
 
 ### Feature Creation and Population
@@ -4607,7 +4607,7 @@ with ml.create_execution(config, dry_run=args.dry_run) as execution:
         for rid, severity in annotations.items()
     ]
     execution.add_features(records)  # Execution RID set automatically
-execution.upload_execution_outputs()
+execution.commit_output_assets()
 ```
 
 ### ETL / Data Loading
@@ -4619,7 +4619,7 @@ with ml.create_execution(config, dry_run=args.dry_run) as execution:
     # Transform and insert
     for record in transform(data):
         execution.insert_record("TargetTable", record)
-    execution.upload_execution_outputs()
+    execution.commit_output_assets()
 ```
 
 ## When MCP Tools Are Still Appropriate
@@ -5836,10 +5836,10 @@ This guide covers common problems encountered when running DerivaML executions a
 
 **Symptom**: Execution completes but asset files are not visible in the catalog.
 
-**Cause**: `exe.upload_execution_outputs()` (Python API) was not called, or files were written to the wrong path.
+**Cause**: `exe.commit_output_assets()` (Python API) was not called, or files were written to the wrong path.
 
 **Solution**:
-1. Call `exe.upload_execution_outputs()` **after** the `with` block exits in Python.
+1. Call `exe.commit_output_assets()` **after** the `with` block exits in Python.
 2. Ensure files are written to the **exact path** returned by `exe.asset_file_path()`. Writing to any other directory will cause the upload to miss those files.
 3. Verify the file actually exists at the path before uploading:
    ```python
@@ -5924,7 +5924,7 @@ This guide covers common problems encountered when running DerivaML executions a
 
 ## Problem: "Upload Timeout"
 
-**Symptom**: `exe.upload_execution_outputs()` (Python API) hangs or times out.
+**Symptom**: `exe.commit_output_assets()` (Python API) hangs or times out.
 
 **Cause**: Large files, network issues, or server limits.
 

--- a/uv.lock
+++ b/uv.lock
@@ -600,8 +600,8 @@ wheels = [
 
 [[package]]
 name = "deriva"
-version = "1.7.12"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=2.0-dev#1a09fe312a03ec2f7841c1ddfc9b62771fbd635a" }
+version = "2.0.0.dev0"
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#ed5ee69c9f65a383f85acc57d9513757a6d0a96e" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -676,8 +676,8 @@ dev = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.28.0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#50859fa9065eb47f9be2c899f36dfe5f0b9121f3" }
+version = "1.38.0"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#f3efbf4933f4b344ddfc50d798f79a88744d9294" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },
@@ -687,6 +687,7 @@ dependencies = [
     { name = "nbconvert" },
     { name = "nbstripout" },
     { name = "nest-asyncio" },
+    { name = "packaging" },
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "papermill" },
@@ -694,7 +695,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "regex" },
     { name = "scikit-learn" },
-    { name = "semver" },
     { name = "setuptools" },
     { name = "setuptools-scm" },
     { name = "sqlalchemy" },
@@ -3187,15 +3187,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
-]
-
-[[package]]
-name = "semver"
-version = "3.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -676,8 +676,8 @@ dev = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.38.0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#f3efbf4933f4b344ddfc50d798f79a88744d9294" }
+version = "2.0.0"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#8d109372db14be04935911da3e592e1723988226" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
Migrates `deriva-mcp` to the unified upload API introduced by
[deriva-ml PR #224](https://github.com/informatics-isi-edu/deriva-ml/pull/224)
(see `deriva-ml/docs/adr/0009-unified-commit-output-assets.md`).

deriva-ml v2.0.0 collapses four legacy upload methods
(`Execution.upload_execution_outputs`, `Execution.upload_outputs`,
`ExecutionSnapshot.upload_outputs(ml=)`, `DerivaML.upload_pending`) into
**one** per-execution method `Execution.commit_output_assets()` plus a
batch sibling `DerivaML.commit_pending_executions()`. The old names are
deleted with no deprecation shims.

## Changes

- **1 production site** — `src/deriva_mcp/connection.py`:
  `execution.upload_execution_outputs(clean_folder=True)` →
  `execution.commit_output_assets(clean_folder=True)` inside the
  `disconnect()` handler. The same method has an unrelated
  `disconnect(upload_outputs: bool = True)` keyword argument that
  remains untouched (it is a flag, not a method reference).
- **Prompt text in `src/deriva_mcp/prompts.py`** — every
  agent-facing reference to `exe.upload_execution_outputs()` /
  `execution.upload_execution_outputs()` updated to
  `commit_output_assets()`, with the surrounding "Upload AFTER the
  with block" / "Upload outputs" prose rephrased to "Commit AFTER the
  with block" / "Commit output assets" where it described the API
  step. Troubleshooting symptom labels ("Files Not Uploaded",
  "Upload Timeout") left as-is because they describe what the user
  observes, not the API call.
- **`README.md` (4 sites) and `CLAUDE.md` (1 site)** — refreshed
  to use `commit_output_assets`.
- **`pyproject.toml`** — pin `deriva-ml>=2.0,<3.0` and refresh
  `uv.lock` so the v1 surface cannot be installed once v2 ships.

## Dependencies

This PR requires deriva-ml v2.0.0 to be installable. The lockfile
currently resolves to the latest deriva-ml git-source revision; once
deriva-ml#224 merges and v2.0 is tagged, `uv lock` will pick up the
true v2 release.

## Repo status

`deriva-mcp` is **legacy** per the workspace-level CLAUDE.md — it is
being replaced by `deriva-mcp-core` + `deriva-ml-mcp`. This PR is
keep-it-building work for the cut-over period; we are not investing
in `deriva-mcp` beyond what is needed to track the deriva-ml API.

## Verification

```
$ grep -rn "upload_execution_outputs|upload_pending" src/ README.md CLAUDE.md
# (no matches)

$ grep -rn "upload_outputs" src/
src/deriva_mcp/connection.py:331:        upload_outputs: bool = True,       # disconnect() kwarg, unrelated
src/deriva_mcp/connection.py:341:            upload_outputs: If True, ...    # docstring for that kwarg
src/deriva_mcp/connection.py:368:                    if upload_outputs:      # ditto
```