### PR TITLE
chore: relax deriva-ml pin to >=1.39,<2.0 (v2 walkback)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.2.0",
-    "deriva-ml>=2.0,<3.0",
+    "deriva-ml>=1.39,<2.0",
     "pydantic>=2.0",
     "pip-system-certs>=5.3",
     "kaggle>=1.8.3",


### PR DESCRIPTION
## Summary

The `v2.0.0` tag on `deriva-ml` was walked back per the maintainer's request — the unified `commit_output_assets` surface needs more bake time before a major-version bump. The same commit (`8d109372`) was re-tagged as `v1.39.0`.

This PR adjusts the declared `pyproject.toml` pin from `>=2.0,<3.0` to `>=1.39,<2.0` to match. The walkback is documented in deriva-ml PR #225.

The lockfile already pointed at the correct commit (`8d109372`) so no resolution change occurred — `uv lock` confirmed the existing lockfile is still valid. This is purely declared-pin cleanup.

**Note:** `deriva-mcp` is the legacy MCP server per workspace CLAUDE.md. The current MCP target is `deriva-mcp-core` + `deriva-ml-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)